### PR TITLE
Segmentation 3D example ported to substra

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Technical documentation is available at [docs.monai.io](https://docs.monai.io).
 ## Contributing
 For guidance on making a contribution to MONAI, see the [contributing guidelines](https://github.com/Project-MONAI/MONAI/blob/master/CONTRIBUTING.md).
 
+## Community
+Join the conversation on Twitter [@ProjectMONAI](https://twitter.com/ProjectMONAI) or join our [Slack channel](https://forms.gle/QTxJq3hFictp31UM9).
+
+Ask and answer questions over on the [PyTorch Forums](https://discuss.pytorch.org/) or [StackOverflow](https://stackoverflow.com/tags/monai). Make sure to tag @monai.
+
 ## Links
 - Website: https://monai.io/
 - API documentation: https://docs.monai.io

--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -15,6 +15,9 @@ Applications
 .. autoclass:: DecathlonDataset
     :members:
 
+.. autoclass:: CVDecathlonDataset
+    :members:
+
 `Utilities`
 -----------
 
@@ -25,3 +28,5 @@ Applications
 .. autofunction:: extractall
 
 .. autofunction:: download_and_extract
+
+.. autofunction:: split_dataset

--- a/docs/source/highlights.md
+++ b/docs/source/highlights.md
@@ -15,7 +15,7 @@ The overall architecture and modules are shown in the following figure:
 ![image](../images/arch_modules_v0.3.png)
 The rest of this page provides more details for each module.
 
-* [Data I/O, processing and augmentation](#medical-image-data-io-processing-and-augmentation)
+* [Data I/O, processing and augmentation](#medical-image-data-i-o-processing-and-augmentation)
 * [Datasets](#datasets)
 * [Loss functions](#losses)
 * [Network architectures](#network-architectures)

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -165,6 +165,22 @@ Layers
 .. autoclass:: monai.networks.layers.AffineTransform
     :members:
 
+`grid_pull`
+~~~~~~~~~~~
+.. autofunction:: monai.networks.layers.grid_pull
+
+`grid_push`
+~~~~~~~~~~~
+.. autofunction:: monai.networks.layers.grid_push
+
+`grid_count`
+~~~~~~~~~~~~
+.. autofunction:: monai.networks.layers.grid_count
+
+`grid_grad`
+~~~~~~~~~~~
+.. autofunction:: monai.networks.layers.grid_grad
+
 `LLTM`
 ~~~~~~
 .. autoclass:: LLTM

--- a/examples/substra/.gitignore
+++ b/examples/substra/.gitignore
@@ -1,0 +1,14 @@
+assets/train_data_samples/
+assets/test_data_samples/
+assets/model
+assets/model-epoch-*
+assets/predictions
+assets/predictions-epoch-*
+assets/algo.zip
+assets/metrics.zip
+sandbox
+
+output/
+runs/
+local-worker/
+best_metric_model.pth

--- a/examples/substra/README.md
+++ b/examples/substra/README.md
@@ -1,0 +1,133 @@
+# MONAI on the Substra platform
+
+This examples demonstrates how to run the [3D segmentation tutorial](https://github.com/Project-MONAI/tutorials/tree/master/3d_segmentation) on the [Substra](https://github.com/substrafoundation/substra) platform.
+
+In order to run the example, you'll need to have an instance of the substra platform running. Please refer to the [Substra documentation](https://doc.substra.ai/) for more information.
+
+## Running the example
+
+### Preliminary
+
+```sh
+pip install -r requirements.txt
+python scripts/generate_data_samples.py
+```
+
+### Testing in debug mode
+
+```sh
+substra config --profile node-1 http://substra-backend.node-1.com
+DEBUG=True python scripts/run_in_substra.py
+```
+
+In debug mode, the scripts run locally and spawns Docker containers to execute the traintuples
+and testtuples. Increase the resources allocated to Docker to avoid memory errors and make the execution faster.
+
+### Running on a deployed Substra platform
+
+If you do not have access to a Substra platform, you can [deploy one locally](https://doc.substra.ai/setup/local_install_skaffold.html).
+
+Connect to Substra using the CLI, for example:
+```sh
+substra config --profile node-1 http://substra-backend.node-1.com
+substra login --profile node-1 --username node-1 --password 'p@$swr0d44'
+```
+
+And launch the script:
+```sh
+python scripts/run_in_substra.py
+```
+
+### Performance
+
+With 40 train data samples, 5 test data samples and 5 epochs, this example runs on GPU in 3 minutes and has a final score of 0.93.
+
+Example output:
+```sh
+...
+Execution took 2.576630981763204 minutes.
+Performance on epoch 0: 0.591707444190979
+Performance on epoch 1: 0.8561596512794495
+Performance on epoch 2: 0.8999291062355042
+Performance on epoch 3: 0.9219937562942505
+Performance on epoch 4: 0.9314350485801697
+```
+
+## Monai to Substra adaptation notes
+
+### Randomization and openers
+
+`substratools.Opener` requests that user implement both get_X and get_y. It gets really tricky when using a randomized batch iterator like DataLoader because we cannot instantiate 2 DataLoader (one in each method) on the same data samples because each loader would be randomized differently and X_i would not match y_i.
+
+Also we cannot use a randomized loader for testtuple, otherwise the order of items in y_pred (generated from one instance of the loader) would not match the one in y_true (generated from another instance of the loader).
+
+A good solution would be to be able to set the order of data samples in the testtuple but this is currently not supported by Substra. If it were, the randomization could be done outside of the opener.
+
+> Note: the randomization is especially important when trying to run multiple epochs (with randomization happing in-between epochs). In substra however each epoch should be a separate traintuple. So it would be perfectly possible to randomize differently the order of data samples at each traintuple.
+
+In the meantime, here are a few solutions:
+
+* Have a separate opener for training and one for testing. This is necessary if we want to keep the randomization.
+* Only load the data once during training, either by:
+  * having get_y return None and get_X return the loader (implemented here)
+  * having get_y and get_X return iterators that iterate over separate parts of the loader (can be tricky)
+
+### Debug mode memory issue
+
+Attempting to run the example using the debug mode will raise a memory error:
+
+```
+ERROR: Unexpected bus error encountered in worker. This might be caused by insufficient shared memory (shm)
+```
+
+By patching the code of the spawner in the substra repo as follows you should be able to run it without trouble.
+
+```diff
+diff --git a/substra/sdk/backends/local/compute/spawner.py b/substra/sdk/backends/local/compute/spawner.py
+index f65b2ae..92af9d8 100644
+--- a/substra/sdk/backends/local/compute/spawner.py
++++ b/substra/sdk/backends/local/compute/spawner.py
+@@ -68,8 +68,6 @@ class DockerSpawner:
+             detach=True,
+             tty=True,
+             stdin_open=True,
+-            ipc_mode="host",
+-            shm_size='8G',
+         )
+
+         execution_logs = []
+```
+
+See https://github.com/pytorch/pytorch#docker-image for reference.
+
+### Misc
+
+* Each prediction is saved as a different file, but substra expects only one file. The strategy was to save all files
+  to a temporary directory and then zip the directory.
+
+* Data sample files have their names stored in metadata. And since these metadata are pushed to the save_prediction,
+  if all files have the same name (just in different folders) the predictions will also all have the same name,
+  overwriting each other.
+
+* NiftiSaver uses the channel last format, which means we have to revert to channel first when loading saved predictions
+
+  Code from NiftiSaver:
+
+  ```python
+  # change data to "channel last" format and write to nifti format file
+  data = np.moveaxis(data, 0, -1)
+  ```
+
+* Sorting data sample path with `sorted(paths)` works locally because each path looks like
+  `~/MONAI/examples/segmentation_3d/assets/train_data_samples/train_data_sample_0/0_im.nii.gz` and therefore share a
+  common path before the `*/*_im.nii.gz`.
+
+  When running in substra, the same file is available at
+  `/tmp/substra/medias/datasamples/<hash>/train_data_sample_0/0_im.nii.gz`. Applying `sorted` to such path will sort
+  not by the number in `train_data_sample_X` but rather by the alphabetical order of hashes.
+
+  However, since predictions are stored in a zip and then unzipped in a common folder, their relative order will be
+  the same as for the local run. Which means the order of predictions and get_y results is the same in local but
+  different in substra.
+
+  The solution was therefore to use the file's basename to sort and not the full path.

--- a/examples/substra/README.md
+++ b/examples/substra/README.md
@@ -4,6 +4,8 @@ This examples demonstrates how to run the [3D segmentation tutorial](https://git
 
 In order to run the example, you'll need to have an instance of the substra platform running. Please refer to the [Substra documentation](https://doc.substra.ai/) for more information.
 
+This is based on the version [0.7.1](https://github.com/SubstraFoundation/substra/releases/tag/0.7.1) of Substra.
+
 ## Running the example
 
 ### Preliminary

--- a/examples/substra/assets/algo/Dockerfile
+++ b/examples/substra/assets/algo/Dockerfile
@@ -5,7 +5,7 @@ FROM substrafoundation/substra-tools:0.6.1
 RUN pip3 install numpy==1.18.2
 RUN pip3 install nibabel
 RUN apt-get update && apt-get install -y git
-RUN pip3 install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+RUN pip3 install git+https://github.com/Project-MONAI/MONAI@0.3.0
 
 # add your algorithm script to docker image
 ADD algo.py .

--- a/examples/substra/assets/algo/Dockerfile
+++ b/examples/substra/assets/algo/Dockerfile
@@ -1,0 +1,14 @@
+# this base image works in both CPU and GPU enabled environments
+FROM substrafoundation/substra-tools:0.6.1
+
+# install dependencies
+RUN pip3 install numpy==1.18.2
+RUN pip3 install nibabel
+RUN apt-get update && apt-get install -y git
+RUN pip3 install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+
+# add your algorithm script to docker image
+ADD algo.py .
+
+# define how script is run
+ENTRYPOINT ["python3", "algo.py"]

--- a/examples/substra/assets/algo/algo.py
+++ b/examples/substra/assets/algo/algo.py
@@ -1,0 +1,83 @@
+import substratools as tools
+import torch
+
+import monai
+from monai.inferers import sliding_window_inference
+
+
+class MonaiAlgo(tools.algo.Algo):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    loss_function = monai.losses.DiceLoss(sigmoid=True)
+
+    def _get_model(self):
+        model = monai.networks.nets.UNet(
+            dimensions=3,
+            in_channels=1,
+            out_channels=1,
+            channels=(16, 32, 64, 128, 256),
+            strides=(2, 2, 2, 2),
+            num_res_units=2,
+        ).to(self.device)
+        optimizer = torch.optim.Adam(model.parameters(), 1e-3)
+        return (model, optimizer)
+
+    def train(self, X, y, models, rank):  # noqa: N803
+        # create UNet, DiceLoss and Adam optimizer
+        if not models:
+            model, optimizer = self._get_model()
+        else:
+            model, optimizer = models[0]
+
+        # start a typical PyTorch training
+        epoch_loss = 0
+        step = 0
+        model.train()
+        for data in X:
+            inputs = data["img"].to(self.device)
+            labels = data["seg"].to(self.device)
+            step += 1
+            optimizer.zero_grad()
+            outputs = model(inputs)
+            loss = self.loss_function(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item()
+            print(f"Step {step}, train_loss:{loss.item()}")
+
+        print(f"Average loss: {epoch_loss / step}")
+
+        return (model, optimizer)
+
+    def predict(self, X, model):  # noqa: N803
+        y_pred = []
+        model, _ = model  # drop the optimizer
+        model.eval()
+        with torch.no_grad():
+            for inputs, metadata in X:
+                inputs = inputs.to(self.device)
+                roi_size = (96, 96, 96)
+                sw_batch_size = 4
+                outputs = sliding_window_inference(inputs, roi_size, sw_batch_size, model)
+                y_pred.append((outputs, metadata))
+        return y_pred
+
+    def load_model(self, path):
+        model, optimizer = self._get_model()
+        data = torch.load(path)
+        model.load_state_dict(data["model_state_dict"])
+        optimizer.load_state_dict(data["optimizer_state_dict"])
+        return model, optimizer
+
+    def save_model(self, model, path):
+        model, optimizer = model
+        torch.save(
+            {
+                "model_state_dict": model.state_dict(),
+                "optimizer_state_dict": optimizer.state_dict(),
+            },
+            path,
+        )
+
+
+if __name__ == "__main__":
+    tools.algo.execute(MonaiAlgo())

--- a/examples/substra/assets/algo/description.md
+++ b/examples/substra/assets/algo/description.md
@@ -1,0 +1,1 @@
+Segmentation 3D - Unet

--- a/examples/substra/assets/objective/Dockerfile
+++ b/examples/substra/assets/objective/Dockerfile
@@ -1,0 +1,14 @@
+# this base image works in both CPU and GPU enabled environments
+FROM substrafoundation/substra-tools:0.6.1
+
+# install dependencies
+RUN pip3 install numpy==1.18.2
+RUN pip3 install nibabel
+RUN apt-get update && apt-get install -y git
+RUN pip3 install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+
+# add your metrics script to docker image
+ADD metrics.py .
+
+# define how script is run
+ENTRYPOINT ["python3", "metrics.py"]

--- a/examples/substra/assets/objective/Dockerfile
+++ b/examples/substra/assets/objective/Dockerfile
@@ -5,7 +5,7 @@ FROM substrafoundation/substra-tools:0.6.1
 RUN pip3 install numpy==1.18.2
 RUN pip3 install nibabel
 RUN apt-get update && apt-get install -y git
-RUN pip3 install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+RUN pip3 install git+https://github.com/Project-MONAI/MONAI@0.3.0
 
 # add your metrics script to docker image
 ADD metrics.py .

--- a/examples/substra/assets/objective/description.md
+++ b/examples/substra/assets/objective/description.md
@@ -1,0 +1,1 @@
+Segmentation 3D - mean dice

--- a/examples/substra/assets/objective/metrics.py
+++ b/examples/substra/assets/objective/metrics.py
@@ -1,0 +1,28 @@
+import substratools as tools
+import torch
+
+from monai.metrics import DiceMetric
+
+
+class MonaiMetrics(tools.Metrics):
+    dice_metric = DiceMetric(include_background=True, to_onehot_y=False, sigmoid=True, reduction="mean")
+
+    def score(self, y_true, y_pred):
+        metric_sum = 0.0
+        metric_count = 0
+        with torch.no_grad():
+            for (val_true, val_pred) in zip(y_true, y_pred):
+                val_true, _ = val_true
+                val_pred, _ = val_pred
+                value = self.dice_metric(
+                    y_pred=val_pred,
+                    y=val_true,
+                )
+                metric_count += len(value)
+                metric_sum += value.item() * len(value)
+        metric = metric_sum / metric_count
+        return metric
+
+
+if __name__ == "__main__":
+    tools.metrics.execute(MonaiMetrics())

--- a/examples/substra/assets/test_dataset/description.md
+++ b/examples/substra/assets/test_dataset/description.md
@@ -1,0 +1,1 @@
+Segmentation 3D - Test

--- a/examples/substra/assets/test_dataset/opener.py
+++ b/examples/substra/assets/test_dataset/opener.py
@@ -1,0 +1,116 @@
+import os
+import tempfile
+import zipfile
+from glob import glob
+
+import nibabel as nib
+import numpy as np
+import substratools as tools
+from torch.utils.data import DataLoader
+
+from monai.data import CacheDataset, NiftiSaver, create_test_image_3d, list_data_collate
+from monai.transforms import AsChannelFirstd, Compose, LoadNiftid, ScaleIntensityd, ToTensord
+
+
+class MonaiTestOpener(tools.Opener):
+    def init(self):
+        self._fake_samples_directory = tempfile.mkdtemp()
+        self._has_generated_fake = False
+
+    def _get_loader(self, folders):
+        images = []
+        segs = []
+        for folder in folders:
+            images += glob(os.path.join(folder, "*_im.nii.gz"))
+            segs += glob(os.path.join(folder, "*_seg.nii.gz"))
+        images = sorted(images, key=os.path.basename)
+        segs = sorted(segs, key=os.path.basename)
+
+        files = [{"img": img, "seg": seg} for img, seg in zip(images, segs)]
+
+        transforms = Compose(
+            [
+                LoadNiftid(keys=["img", "seg"]),
+                AsChannelFirstd(keys=["img", "seg"], channel_dim=-1),
+                ScaleIntensityd(keys="img"),
+                ToTensord(keys=["img", "seg"]),
+            ]
+        )
+
+        ds = CacheDataset(data=files, transform=transforms)
+        loader = DataLoader(ds, batch_size=1, num_workers=4, collate_fn=list_data_collate)
+
+        return loader
+
+    def _get_X_iterator(self, loader):  # noqa: N802
+        for data in loader:
+            yield (data["img"], data["img_meta_dict"])
+
+    def _get_y_iterator(self, loader):
+        for data in loader:
+            yield (data["seg"], data["seg_meta_dict"])
+
+    def get_X(self, folders):  # noqa: N802
+        loader = self._get_loader(folders)
+        return self._get_X_iterator(loader)
+
+    def get_y(self, folders):
+        loader = self._get_loader(folders)
+        return self._get_y_iterator(loader)
+
+    def save_predictions(self, y_pred, path):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saver = NiftiSaver(output_dir=tmp_dir)
+            for outputs, metadata in y_pred:
+                saver.save_batch(outputs, metadata)
+            # join all predictions in a single zip
+            with zipfile.ZipFile(path, "w") as z:
+                for filepath in glob(os.path.join(tmp_dir, "*/*")):
+                    z.write(filepath, arcname=os.path.relpath(filepath, tmp_dir))
+
+    def _get_predictions_iterator(self, segs):
+        files = [{"seg": seg} for seg in segs]
+        transforms = Compose(
+            [
+                LoadNiftid(keys=["seg"]),
+                AsChannelFirstd(keys=["seg"], channel_dim=-1),
+                ToTensord(keys=["seg"]),
+            ]
+        )
+        ds = CacheDataset(data=files, transform=transforms)
+        loader = DataLoader(ds, batch_size=1, num_workers=4, collate_fn=list_data_collate)
+        for data in loader:
+            yield (data["seg"], data["seg_meta_dict"])
+
+    def get_predictions(self, path):
+        # unzip predictions
+        tmp_dir = tempfile.mkdtemp()
+        with zipfile.ZipFile(path, "r") as z:
+            z.extractall(tmp_dir)
+        # load predictions
+        segs = sorted(glob(os.path.join(tmp_dir, "*/*_seg.nii.gz")), key=os.path.basename)
+        return self._get_predictions_iterator(segs)
+
+    def _generate_fake_samples(self, n_samples):
+        prefix = "test"
+        for i in range(n_samples):
+            im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
+
+            n = nib.Nifti1Image(im, np.eye(4))
+            nib.save(n, os.path.join(self._fake_samples_directory, f"{prefix}_{i}_im.nii.gz"))
+
+            n = nib.Nifti1Image(seg, np.eye(4))
+            nib.save(n, os.path.join(self._fake_samples_directory, f"{prefix}_{i}_seg.nii.gz"))
+        self._has_generated_fake = True
+
+    def fake_X(self, n_samples):  # noqa: N802
+        if not self._has_generated_fake:
+            self._generate_fake_samples(n_samples=n_samples)
+        loader = self._get_loader([self._fake_samples_directory])
+        return self._get_X_iterator(loader)
+
+    def fake_y(self, n_samples):
+        if not self._has_generated_fake:
+            self._generate_fake_samples(n_samples=n_samples)
+        loader = self._get_loader([self._fake_samples_directory])
+        return self._get_X_iterator(loader)

--- a/examples/substra/assets/train_dataset/description.md
+++ b/examples/substra/assets/train_dataset/description.md
@@ -1,0 +1,1 @@
+Segmentation 3D - Train

--- a/examples/substra/assets/train_dataset/opener.py
+++ b/examples/substra/assets/train_dataset/opener.py
@@ -1,0 +1,91 @@
+import os
+import tempfile
+from glob import glob
+
+import nibabel as nib
+import substratools as tools
+import torch
+from torch.utils.data import DataLoader
+
+from monai.data import CacheDataset, create_test_image_3d, list_data_collate
+from monai.transforms import (
+    AsChannelFirstd,
+    Compose,
+    LoadNiftid,
+    RandCropByPosNegLabeld,
+    RandRotate90d,
+    ScaleIntensityd,
+    ToTensord,
+)
+
+
+class MonaiTrainOpener(tools.Opener):
+    def init(self):
+        self._fake_samples_directory = tempfile.mkdtemp()
+
+    def _get_loader(self, folders):
+        images = []
+        segs = []
+        for folder in folders:
+            images += glob(os.path.join(folder, "*_im.nii.gz"))
+            segs += glob(os.path.join(folder, "*_seg.nii.gz"))
+        images = sorted(images, key=os.path.basename)
+        segs = sorted(segs, key=os.path.basename)
+
+        files = [{"img": img, "seg": seg} for img, seg in zip(images, segs)]
+
+        transforms = Compose(
+            [
+                LoadNiftid(keys=["img", "seg"]),
+                AsChannelFirstd(keys=["img", "seg"], channel_dim=-1),
+                ScaleIntensityd(keys="img"),
+                RandCropByPosNegLabeld(
+                    keys=["img", "seg"], label_key="seg", spatial_size=[96, 96, 96], pos=1, neg=1, num_samples=4
+                ),
+                RandRotate90d(keys=["img", "seg"], prob=0.5, spatial_axes=[0, 2]),
+                ToTensord(keys=["img", "seg"]),
+            ]
+        )
+
+        ds = CacheDataset(data=files, transform=transforms)
+        loader = DataLoader(
+            ds,
+            batch_size=2,
+            shuffle=True,
+            num_workers=4,
+            collate_fn=list_data_collate,
+            pin_memory=torch.cuda.is_available(),
+        )
+
+        return loader
+
+    def get_X(self, folders):  # noqa: N802
+        loader = self._get_loader(folders)
+        return loader
+
+    def get_y(self, folders):
+        return None
+
+    def save_predictions(self, y_pred, path):
+        raise NotImplementedError
+
+    def get_predictions(self, path):
+        raise NotImplementedError
+
+    def _generate_fake_samples(self, n_samples):
+        prefix = "test"
+        for i in range(n_samples):
+            im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
+
+            n = nib.Nifti1Image(im, np.eye(4))
+            nib.save(n, os.path.join(self._fake_samples_directory, f"{prefix}_{i}_im.nii.gz"))
+
+            n = nib.Nifti1Image(seg, np.eye(4))
+            nib.save(n, os.path.join(self._fake_samples_directory, f"{prefix}_{i}_seg.nii.gz"))
+
+    def fake_X(self, n_samples):  # noqa: N802
+        self._generate_fake_samples(n_samples=n_samples)
+        return self._get_loader([self._fake_samples_directory])
+
+    def fake_y(self, n_samples):
+        return None

--- a/examples/substra/requirements.txt
+++ b/examples/substra/requirements.txt
@@ -1,0 +1,1 @@
+nibabel

--- a/examples/substra/scripts/generate_data_samples.py
+++ b/examples/substra/scripts/generate_data_samples.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+
+import nibabel as nib
+import numpy as np
+
+from monai.data import create_test_image_3d
+
+root_path = os.path.dirname(__file__)
+asset_path = os.path.join(root_path, "../assets")
+
+
+def generate_data_sample(path, prefix):
+    im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
+
+    n = nib.Nifti1Image(im, np.eye(4))
+    nib.save(n, os.path.join(path, f"{prefix}_im.nii.gz"))
+
+    n = nib.Nifti1Image(seg, np.eye(4))
+    nib.save(n, os.path.join(path, f"{prefix}_seg.nii.gz"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n-train-data-samples", type=int, default=40, help="Number of train data samples to generate")
+    parser.add_argument("--n-test-data-samples", type=int, default=5, help="Number of test data samples to generate")
+    args = parser.parse_args()
+
+    print(f"Generating {args.n_train_data_samples} train data samples and {args.n_test_data_samples} test data samples")
+
+    for i in range(args.n_train_data_samples):
+        path = os.path.join(asset_path, f"train_data_samples/train_data_sample_{i}")
+        os.makedirs(path, exist_ok=True)
+        generate_data_sample(path, prefix=i)
+
+    for i in range(args.n_test_data_samples):
+        path = os.path.join(asset_path, f"test_data_samples/test_data_sample_{i}")
+        os.makedirs(path, exist_ok=True)
+        generate_data_sample(path, prefix=i)

--- a/examples/substra/scripts/run_in_substra.py
+++ b/examples/substra/scripts/run_in_substra.py
@@ -1,0 +1,197 @@
+import os
+import time
+import zipfile
+from distutils.util import strtobool
+from pathlib import Path
+
+import substra
+
+N_EPOCHS = 5
+N_TRAIN_SAMPLES = 40  # Max 40
+DEBUG = bool(strtobool(os.environ.get("DEBUG", "False")))
+
+# Path to the assets folder
+ASSETS_DIR = Path(__file__).parents[1].resolve() / "assets"
+
+# List of train data sample folders
+TRAIN_DATA_SAMPLE_FOLDERS = [f for f in (ASSETS_DIR / "train_data_samples").iterdir() if f.is_dir()][
+    :N_TRAIN_SAMPLES
+]  # Keep only n train samples
+
+# List of test data sample folders
+TEST_DATA_SAMPLE_FOLDERS = [f for f in (ASSETS_DIR / "test_data_samples").iterdir() if f.is_dir()]
+
+
+def build_archive(name, files):
+    """Create a zip archive from files"""
+    archive = ASSETS_DIR / name
+    with zipfile.ZipFile(archive, "w") as z:
+        for filepath in files:
+            z.write(filepath, arcname=filepath.name)
+    return archive
+
+
+# Connect to Substra
+client = substra.Client.from_config_file(profile_name="node-1", debug=DEBUG)
+
+# Create a dataset
+print("Adding train dataset")
+train_dataset_key = client.add_dataset(
+    {
+        "name": "Segmentation 3D - Train",
+        "description": ASSETS_DIR / "train_dataset" / "description.md",
+        "type": "3D images",
+        "data_opener": ASSETS_DIR / "train_dataset" / "opener.py",
+        "objective_key": None,
+        "permissions": {
+            "public": True,
+            "authorized_ids": list(),
+        },
+    },
+    exist_ok=True,
+)
+
+# Create the train data samples
+train_data_sample_keys = []
+for i, train_data_sample_folder in enumerate(TRAIN_DATA_SAMPLE_FOLDERS):
+    print(f"Adding train data sample {i+1}/{len(TRAIN_DATA_SAMPLE_FOLDERS)}")
+    data_sample_key = client.add_data_sample(
+        {
+            "path": train_data_sample_folder,
+            "data_manager_keys": [train_dataset_key],
+            "test_only": False,
+        },
+        exist_ok=True,
+    )
+    train_data_sample_keys.append(data_sample_key)
+
+train_dataset = client.get_dataset(train_dataset_key)
+
+# Create the test dataset
+print("Adding test dataset")
+test_dataset_key = client.add_dataset(
+    {
+        "name": "Segmentation 3D - Test",
+        "description": ASSETS_DIR / "test_dataset" / "description.md",
+        "type": "3D images",
+        "data_opener": ASSETS_DIR / "test_dataset" / "opener.py",
+        "objective_key": None,
+        "permissions": {
+            "public": True,
+            "authorized_ids": list(),
+        },
+    },
+    exist_ok=True,
+)
+
+# Create the test data samples
+test_data_sample_keys = []
+for i, test_data_sample_folder in enumerate(TEST_DATA_SAMPLE_FOLDERS):
+    print(f"Adding test data sample {i+1}/{len(TEST_DATA_SAMPLE_FOLDERS)}")
+    data_sample_key = client.add_data_sample(
+        {
+            "path": test_data_sample_folder,
+            "data_manager_keys": [test_dataset_key],
+            "test_only": True,
+        },
+        exist_ok=True,
+    )
+    test_data_sample_keys.append(data_sample_key)
+
+test_dataset = client.get_dataset(test_dataset_key)
+
+# Create the objective (metrics)
+print("Adding objective")
+metrics_archive = build_archive(
+    "metrics.zip",
+    [
+        ASSETS_DIR / "objective" / "metrics.py",
+        ASSETS_DIR / "objective" / "Dockerfile",
+    ],
+)
+objective_key = client.add_objective(
+    {
+        "name": "Segmentation 3D",
+        "description": ASSETS_DIR / "objective" / "description.md",
+        "metrics_name": "mean dice",
+        "metrics": metrics_archive,
+        "test_data_manager_key": test_dataset_key,
+        "test_data_sample_keys": test_data_sample_keys,
+        "permissions": {
+            "public": True,
+            "authorized_ids": list(),
+        },
+    },
+    exist_ok=True,
+)
+
+# Create the algo
+print("Adding algo")
+algo_archive = build_archive(
+    "algo.zip",
+    [
+        ASSETS_DIR / "algo" / "algo.py",
+        ASSETS_DIR / "algo" / "Dockerfile",
+    ],
+)
+algo_key = client.add_algo(
+    {
+        "name": "UNet",
+        "description": ASSETS_DIR / "algo" / "description.md",
+        "file": algo_archive,
+        "permissions": {
+            "public": True,
+            "authorized_ids": list(),
+        },
+    },
+    exist_ok=True,
+)
+
+# Create the compute plan: one traintuple and testtuple per epoch
+print("Adding compute plan")
+traintuples = []
+testtuples = []
+traintuple = None
+for epoch_number in range(N_EPOCHS):
+    traintuple = {
+        "traintuple_id": epoch_number,
+        "algo_key": algo_key,
+        "data_manager_key": train_dataset_key,
+        "train_data_sample_keys": train_dataset.train_data_sample_keys,
+        "in_models_ids": [traintuple["traintuple_id"]] if traintuple else [],
+    }
+    testtuple = {
+        "objective_key": objective_key,
+        "traintuple_id": traintuple["traintuple_id"],
+    }
+    traintuples.append(traintuple)
+    testtuples.append(testtuple)
+
+print("Waiting for compute plan to finish")
+start = time.time()
+
+compute_plan = client.add_compute_plan(
+    {
+        "traintuples": traintuples,
+        "testtuples": testtuples,
+    }
+)
+
+# In normal (not debug) mode, the execution is asynchronous so we poll the platform
+# every 10s to check the progress of the execution.
+while True:
+    compute_plan = client.get_compute_plan(compute_plan.compute_plan_id)
+    testtuples = [client.get_testtuple(testtuple_key) for testtuple_key in compute_plan.testtuple_keys]
+    testtuples = sorted(testtuples, key=lambda x: x.rank)
+    for testtuple in testtuples:
+        if testtuple.status == "done":
+            print(f"Performance on epoch {testtuple.rank}: {testtuple.dataset.perf:.2f}")
+    print(
+        f"  - {compute_plan.done_count}/{compute_plan.tuple_count} traintuple and testtuples done in {time.time() - start:.2f}s"
+    )
+    if compute_plan.status in ["done", "failed"]:
+        break
+    time.sleep(10)
+
+end = time.time()
+print(f"Execution took {(end - start)/60:.2f} minutes with the status {compute_plan.status}")

--- a/monai/apps/datasets.py
+++ b/monai/apps/datasets.py
@@ -13,7 +13,9 @@ import os
 import sys
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
-from monai.apps.utils import download_and_extract
+import numpy as np
+
+from monai.apps.utils import download_and_extract, split_dataset
 from monai.data import CacheDataset, load_decathlon_datalist, load_decathlon_properties
 from monai.transforms import LoadNiftid, LoadPNGd, Randomizable
 from monai.utils import ensure_tuple
@@ -151,11 +153,10 @@ class DecathlonDataset(Randomizable, CacheDataset):
             for further usage, use `AddChanneld` or `AsChannelFirstd` to convert the shape to [C, H, W, D].
         download: whether to download and extract the Decathlon from resource link, default is False.
             if expected file already exists, skip downloading even set it to True.
+        val_frac: percentage of of validation fraction in the whole dataset, default is 0.2.
             user can manually copy tar file or dataset folder to the root directory.
-        seed: random seed to randomly split `training`, `validation` and `test` datasets, default is 0.
-        val_frac: percentage of of validation fraction from the `training` section, default is 0.2.
-            Decathlon data only contains `training` section with labels and `test` section without labels,
-            so randomly select fraction from the `training` section as the `validation` section.
+        seed: random seed to randomly shuffle the datalist before splitting into training and validation, default is 0.
+            note to set same seed for `training` and `validation` sections.
         cache_num: number of items to be cached. Default is `sys.maxsize`.
             will take the minimum of (cache_num, data_length x cache_rate, data_length).
         cache_rate: percentage of cached data in total, default is 1.0 (cache all).
@@ -181,11 +182,11 @@ class DecathlonDataset(Randomizable, CacheDataset):
             ]
         )
 
-        data = DecathlonDataset(
-            root_dir="./", task="Task09_Spleen", transform=transform, section="validation", download=True
+        val_data = DecathlonDataset(
+            root_dir="./", task="Task09_Spleen", transform=transform, section="validation", seed=12345, download=True
         )
 
-        print(data[0]["image"], data[0]["label"])
+        print(val_data[0]["image"], val_data[0]["label"])
 
     """
 
@@ -243,6 +244,7 @@ class DecathlonDataset(Randomizable, CacheDataset):
             raise RuntimeError(
                 f"Cannot find dataset directory: {dataset_dir}, please use download=True to download it."
             )
+        self.indices: np.ndarray = np.array([])
         data = self._generate_data_list(dataset_dir)
         # as `release` key has typo in Task04 config file, ignore it.
         property_keys = [
@@ -259,8 +261,15 @@ class DecathlonDataset(Randomizable, CacheDataset):
         self._properties = load_decathlon_properties(os.path.join(dataset_dir, "dataset.json"), property_keys)
         super().__init__(data, transform, cache_num=cache_num, cache_rate=cache_rate, num_workers=num_workers)
 
-    def randomize(self, data: Optional[Any] = None) -> None:
-        self.rann = self.R.random()
+    def get_indices(self) -> np.ndarray:
+        """
+        Get the indices of datalist used in this dataset.
+
+        """
+        return self.indices
+
+    def randomize(self, data: List[int]) -> None:
+        self.R.shuffle(data)
 
     def get_properties(self, keys: Optional[Union[Sequence[str], str]] = None):
         """
@@ -278,17 +287,128 @@ class DecathlonDataset(Randomizable, CacheDataset):
     def _generate_data_list(self, dataset_dir: str) -> List[Dict]:
         section = "training" if self.section in ["training", "validation"] else "test"
         datalist = load_decathlon_datalist(os.path.join(dataset_dir, "dataset.json"), True, section)
-        if section == "test":
+        return self._split_datalist(datalist)
+
+    def _split_datalist(self, datalist: List[Dict]) -> List[Dict]:
+        if self.section == "test":
             return datalist
         else:
-            data = list()
-            for i in datalist:
-                self.randomize()
-                if self.section == "training":
-                    if self.rann < self.val_frac:
-                        continue
+            length = len(datalist)
+            indices = np.arange(length)
+            self.randomize(indices)
+
+            val_length = int(length * self.val_frac)
+            if self.section == "training":
+                self.indices = indices[val_length:]
+            else:
+                self.indices = indices[:val_length]
+
+            return [datalist[i] for i in self.indices]
+
+
+class CVDecathlonDataset:
+    """
+    Cross vaidation dataset based on the general `DecathlonDataset`.
+
+    Args:
+        root_dir: user's local directory for caching and loading the MSD datasets.
+        task: which task to download and execute: one of list ("Task01_BrainTumour", "Task02_Heart",
+            "Task03_Liver", "Task04_Hippocampus", "Task05_Prostate", "Task06_Lung", "Task07_Pancreas",
+            "Task08_HepaticVessel", "Task09_Spleen", "Task10_Colon").
+        transform: transforms to execute operations on input data. the default transform is `LoadNiftid`,
+            which can load Nifti format data into numpy array with [H, W, D] or [H, W, D, C] shape.
+            for further usage, use `AddChanneld` or `AsChannelFirstd` to convert the shape to [C, H, W, D].
+        download: whether to download and extract the Decathlon from resource link, default is False.
+            if expected file already exists, skip downloading even set it to True.
+        seed: random seed to randomly shuffle the datalist before splitting into N folds, default is 0.
+            note to set same seed for all the related datasets(`training` and `validation` sections in all N folds).
+        nsplits: number of folds, split the training data into N folds. each fold is then used once as a
+            validation while the N - 1 remaining folds form the training set.
+        cache_num: number of items to be cached. Default is `sys.maxsize`.
+            will take the minimum of (cache_num, data_length x cache_rate, data_length).
+        cache_rate: percentage of cached data in total, default is 1.0 (cache all).
+            will take the minimum of (cache_num, data_length x cache_rate, data_length).
+        num_workers: the number of worker threads to use.
+            if 0 a single thread will be used. Default is 0.
+
+    Example of 5 folds cross validation training::
+
+        # use same random seed for all the datasets
+        cvdataset = CVDecathlonDataset(root_dir="./", task="Task09_Spleen", seed=12345, nsplts=5, download=True)
+        dataset_fold0_train = cvdataset.get_dataset(fold=0, section="training")
+        dataset_fold0_val = cvdataset.get_dataset(fold=0, section="validation")
+        # execute training for fold 0 ...
+
+        dataset_fold1_train = cvdataset.get_dataset(fold=1, section="training")
+        dataset_fold1_val = cvdataset.get_dataset(fold=1, section="validation")
+        # execute training for fold 1 ...
+
+        ...
+
+        dataset_fold4_train = ...
+        # execute training for fold 4 ...
+
+    """
+
+    def __init__(
+        self,
+        root_dir: str,
+        task: str,
+        transform: Union[Sequence[Callable], Callable] = LoadNiftid(["image", "label"]),
+        download: bool = False,
+        seed: int = 0,
+        nsplits: int = 5,
+        cache_num: int = sys.maxsize,
+        cache_rate: float = 1.0,
+        num_workers: int = 0,
+    ) -> None:
+        self.root_dir = root_dir
+        self.task = task
+        self.transform = transform
+        self.download = download
+        self.seed = seed
+        if nsplits < 2:
+            raise ValueError("nplits must be greater than 1 for cross validation.")
+        self.nsplits = nsplits
+        self.cache_num = cache_num
+        self.cache_rate = cache_rate
+        self.num_workers = num_workers
+
+    def get_dataset(self, fold: int, section: str):
+        """
+        Generate dataset for specified fold index and section in the cross validation group.
+
+        Args:
+            fold: index of fold for training and validation.
+            section: expected data section, can be: `training` or `validation`.
+
+        """
+        if fold > self.nsplits - 1:
+            raise ValueError("fold index should be in [0, nsplit - 1].")
+        nsplits = self.nsplits
+
+        class _NsplitsDataset(DecathlonDataset):
+            def _split_datalist(self, datalist: List[Dict]) -> List[Dict]:
+                if section not in ["training", "validation"]:
+                    raise ValueError("section must be training or validation.")
+                length = len(datalist)
+                indices = np.arange(length)
+                self.randomize(indices)
+                fold_indices = split_dataset(nsplits, length)
+                if section == "training":
+                    self.indices = np.delete(indices, np.s_[fold_indices[fold][0] : fold_indices[fold][1]], axis=None)
                 else:
-                    if self.rann >= self.val_frac:
-                        continue
-                data.append(i)
-            return data
+                    self.indices = indices[fold_indices[fold][0] : fold_indices[fold][1]]
+                return [datalist[i] for i in self.indices]
+
+        return _NsplitsDataset(
+            root_dir=self.root_dir,
+            task=self.task,
+            section=section,
+            transform=self.transform,
+            download=self.download,
+            seed=self.seed,
+            cache_num=self.cache_num,
+            cache_rate=self.cache_rate,
+            num_workers=self.num_workers,
+        )

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Optional
 from urllib.error import ContentTooShortError, HTTPError, URLError
 from urllib.request import Request, urlopen, urlretrieve
 
+import numpy as np
+
 from monai.utils import min_version, optional_import
 
 gdown, has_gdown = optional_import("gdown", "3.6")
@@ -249,3 +251,22 @@ def download_and_extract(
     """
     download_url(url=url, filepath=filepath, hash_val=hash_val, hash_type=hash_type)
     extractall(filepath=filepath, output_dir=output_dir, hash_val=hash_val, hash_type=hash_type)
+
+
+def split_dataset(nsplits: int, length: int):
+    """
+    Split dataset into N folds, return a list of indices for every fold.
+
+    Args:
+        nsplits: expected fold number.
+        length: dataset size in total.
+
+    """
+    sizes = np.full(nsplits, length // nsplits, dtype=np.int)
+    sizes[: length % nsplits] += 1
+    indices = list()
+    pos = 0
+    for size in sizes:
+        indices.append([pos, pos + size])
+        pos += size
+    return indices

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 
 import monai
+from monai.utils import OptionalImportError, optional_import
 
 try:
     import ignite
@@ -92,6 +93,13 @@ except (ImportError, AttributeError):
     tqdm_version = "NOT INSTALLED or UNKNOWN VERSION."
 
 
+try:
+    _, HAS_EXT = optional_import("monai._C")
+    USE_COMPILED = HAS_EXT and os.getenv("BUILD_MONAI", "0") == "1"
+except (OptionalImportError, ImportError, AttributeError):
+    HAS_EXT = USE_COMPILED = False
+
+
 def get_config_values():
     """
     Read the package versions into a dictionary.
@@ -135,6 +143,7 @@ def print_config(file=sys.stdout):
     """
     for k, v in get_config_values().items():
         print(f"{k} version: {v}", file=file, flush=True)
+    print(f"MONAI flags: HAS_EXT = {HAS_EXT}, USE_COMPILED = {USE_COMPILED}")
 
     print("\nOptional dependencies:", file=file, flush=True)
     for k, v in get_optional_config_values().items():

--- a/monai/csrc/ext.cpp
+++ b/monai/csrc/ext.cpp
@@ -13,9 +13,45 @@ limitations under the License.
 
 #include <torch/extension.h>
 #include "lltm/lltm.h"
+#include "resample/pushpull.h"
+#include "utils/resample_utils.h"
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // lltm
   m.def("lltm_forward", &lltm_forward, "LLTM forward");
   m.def("lltm_backward", &lltm_backward, "LLTM backward");
+
+  // resample bound mode
+  py::enum_<monai::BoundType>(m, "BoundType")
+      .value("replicate", monai::BoundType::Replicate)
+      .value("dct1", monai::BoundType::DCT1)
+      .value("dct2", monai::BoundType::DCT2)
+      .value("dst1", monai::BoundType::DST1)
+      .value("dst2", monai::BoundType::DST2)
+      .value("dft", monai::BoundType::DFT)
+      .value("sliding", monai::BoundType::Sliding)
+      .value("zero", monai::BoundType::Zero)
+      .export_values();
+
+  // resample interpolation mode
+  py::enum_<monai::InterpolationType>(m, "InterpolationType")
+      .value("nearest", monai::InterpolationType::Nearest)
+      .value("linear", monai::InterpolationType::Linear)
+      .value("quadratic", monai::InterpolationType::Quadratic)
+      .value("cubic", monai::InterpolationType::Cubic)
+      .value("fourth", monai::InterpolationType::FourthOrder)
+      .value("fifth", monai::InterpolationType::FifthOrder)
+      .value("sixth", monai::InterpolationType::SixthOrder)
+      .value("seventh", monai::InterpolationType::SeventhOrder)
+      .export_values();
+
+  // resample
+  m.def("grid_pull", &monai::grid_pull, "GridPull");
+  m.def("grid_pull_backward", &monai::grid_pull_backward, "GridPull backward");
+  m.def("grid_push", &monai::grid_push, "GridPush");
+  m.def("grid_push_backward", &monai::grid_push_backward, "GridPush backward");
+  m.def("grid_count", &monai::grid_count, "GridCount");
+  m.def("grid_count_backward", &monai::grid_count_backward, "GridCount backward");
+  m.def("grid_grad", &monai::grid_grad, "GridGrad");
+  m.def("grid_grad_backward", &monai::grid_grad_backward, "GridGrad backward");
 }

--- a/monai/csrc/resample/bounds_common.h
+++ b/monai/csrc/resample/bounds_common.h
@@ -1,0 +1,243 @@
+/*
+Copyright 2020 MONAI Consortium
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// adapted from https://github.com/balbasty/nitorch
+
+#pragma once
+
+// This file contains static functions for handling out-of-bound indices.
+// They implement typical boundary conditions (those of standard discrete
+// transforms) + a few other cases (replicated border, zeros, sliding)
+// It also defines an enumerated types that encodes each boundary type.
+// The entry points are:
+// . monai::bound::index -> wrap out-of-bound indices
+// . monai::bound::sign  -> optional out-of-bound sign change (sine transforms)
+// . monai::BoundType    -> enumerated boundary type
+//
+// Everything in this file should have internal linkage (static) except
+// the BoundType/BoundVectorRef types.
+
+#include "utils/resample_utils.h"
+
+namespace monai {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//                             INDEXING
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+namespace _index {
+
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE size_t inbounds(size_t coord, size_t size) {
+  return coord;
+}
+
+// Boundary condition of a DCT-I (periodicity: (n-1)*2)
+// Indices are reflected about the centre of the border elements:
+//    -1 --> 1
+//     n --> n-2
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE size_t reflect1c(size_t coord, size_t size) {
+  if (size == 1)
+    return 0;
+  size_t size_twice = (size - 1) * 2;
+  coord = coord < 0 ? -coord : coord;
+  coord = coord % size_twice;
+  coord = coord >= size ? size_twice - coord : coord;
+  return coord;
+}
+
+// Boundary condition of a DST-I (periodicity: (n+1)*2)
+// Indices are reflected about the centre of the first out-of-bound
+// element:
+//    -1 --> undefined [0]
+//    -2 --> 0
+//     n --> undefined [n-1]
+//   n+1 --> n-1
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE size_t reflect1s(size_t coord, size_t size) {
+  if (size == 1)
+    return 0;
+  size_t size_twice = (size + 1) * 2;
+  coord = coord == -1 ? 0 : coord < 0 ? -coord - 2 : coord;
+  coord = coord % size_twice;
+  coord = coord == size ? size - 1 : coord > size ? size_twice - coord - 2 : coord;
+  return coord;
+}
+
+// Boundary condition of a DCT/DST-II (periodicity: n*2)
+// Indices are reflected about the edge of the border elements:
+//    -1 --> 0
+//     n --> n-1
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE size_t reflect2(size_t coord, size_t size) {
+  size_t size_twice = size * 2;
+  coord = coord < 0 ? size_twice - ((-coord - 1) % size_twice) - 1 : coord % size_twice;
+  coord = coord >= size ? size_twice - coord - 1 : coord;
+  return coord;
+}
+
+// Boundary condition of a DFT (periodicity: n)
+// Indices wrap about the edges:
+//    -1 --> n-1
+//     n --> 0
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE size_t circular(size_t coord, size_t size) {
+  coord = coord < 0 ? (size + coord % size) % size : coord % size;
+  return coord;
+}
+
+// Replicate edge values:
+//    -1 --> 0
+//    -2 --> 0
+//     n --> n-1
+//   n+1 --> n-1
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE size_t replicate(size_t coord, size_t size) {
+  coord = coord <= 0 ? 0 : coord >= size ? size - 1 : coord;
+  return coord;
+}
+
+} // namespace _index
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//                          SIGN MODIFICATION
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+namespace _sign {
+
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE int8_t inbounds(size_t coord, size_t size) {
+  return coord < 0 || coord >= size ? 0 : 1;
+}
+
+// Boundary condition of a DCT/DFT
+// No sign modification based on coordinates
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE int8_t constant(size_t coord, size_t size) {
+  return static_cast<int8_t>(1);
+}
+
+// Boundary condition of a DST-I
+// Periodic sign change based on coordinates
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE int8_t periodic1(size_t coord, size_t size) {
+  if (size == 1)
+    return 1;
+  size_t size_twice = (size + 1) * 2;
+  coord = coord < 0 ? size - coord - 1 : coord;
+  coord = coord % size_twice;
+  if (coord % (size + 1) == size)
+    return static_cast<int8_t>(0);
+  else if ((coord / (size + 1)) % 2)
+    return static_cast<int8_t>(-1);
+  else
+    return static_cast<int8_t>(1);
+}
+
+// Boundary condition of a DST-II
+// Periodic sign change based on coordinates
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE int8_t periodic2(size_t coord, size_t size) {
+  coord = (coord < 0 ? size - coord - 1 : coord);
+  return static_cast<int8_t>((coord / size) % 2 ? -1 : 1);
+}
+
+} // namespace _sign
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//                                BOUND
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// Check if coordinates within bounds
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE bool inbounds(size_t coord, size_t size) {
+  return coord >= 0 && coord < size;
+}
+
+template <typename scalar_t, typename size_t>
+static MONAI_INLINE MONAI_DEVICE bool inbounds(scalar_t coord, size_t size, scalar_t tol) {
+  return coord >= -tol && coord < (scalar_t)(size - 1) + tol;
+}
+
+namespace bound {
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t
+get(const scalar_t* ptr, offset_t offset, int8_t sign = static_cast<int8_t>(1)) {
+  if (sign == -1)
+    return -ptr[offset];
+  else if (sign)
+    return ptr[offset];
+  else
+    return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void add(
+    scalar_t* ptr,
+    offset_t offset,
+    scalar_t val,
+    int8_t sign = static_cast<int8_t>(1)) {
+  if (sign == -1)
+    MONAI_ATOMIC_ADD(ptr, offset, -val);
+  else if (sign)
+    MONAI_ATOMIC_ADD(ptr, offset, val);
+}
+
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE int64_t index(BoundType bound_type, size_t coord, size_t size) {
+  switch (bound_type) {
+    case BoundType::Replicate:
+      return _index::replicate(coord, size);
+    case BoundType::DCT1:
+      return _index::reflect1c(coord, size);
+    case BoundType::DCT2:
+      return _index::reflect2(coord, size);
+    case BoundType::DST1:
+      return _index::reflect1s(coord, size);
+    case BoundType::DST2:
+      return _index::reflect2(coord, size);
+    case BoundType::DFT:
+      return _index::circular(coord, size);
+    case BoundType::Zero:
+      return _index::inbounds(coord, size);
+    default:
+      return _index::inbounds(coord, size);
+  }
+}
+
+template <typename size_t>
+static MONAI_INLINE MONAI_DEVICE int8_t sign(BoundType bound_type, size_t coord, size_t size) {
+  switch (bound_type) {
+    case BoundType::Replicate:
+      return _sign::constant(coord, size);
+    case BoundType::DCT1:
+      return _sign::constant(coord, size);
+    case BoundType::DCT2:
+      return _sign::constant(coord, size);
+    case BoundType::DST1:
+      return _sign::periodic1(coord, size);
+    case BoundType::DST2:
+      return _sign::periodic2(coord, size);
+    case BoundType::DFT:
+      return _sign::constant(coord, size);
+    case BoundType::Zero:
+      return _sign::inbounds(coord, size);
+    default:
+      return _sign::inbounds(coord, size);
+  }
+}
+
+} // namespace bound
+} // namespace monai

--- a/monai/csrc/resample/interpolation_common.h
+++ b/monai/csrc/resample/interpolation_common.h
@@ -1,0 +1,861 @@
+/*
+Copyright 2020 MONAI Consortium
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// adapted from https://github.com/balbasty/nitorch
+
+#pragma once
+
+// This file contains static functions for handling (0-7 order)
+// interpolation weights.
+// It also defines an enumerated types that encodes each boundary type.
+// The entry points are:
+// . monai::interpolation::weight     -> node weight based on distance
+// . monai::interpolation::fastweight -> same, assuming x lies in support
+// . monai::interpolation::grad       -> weight derivative // oriented distance
+// . monai::interpolation::fastgrad   -> same, assuming x lies in support
+// . monai::interpolation::hess       -> weight 2nd derivative // oriented distance
+// . monai::interpolation::fasthess   -> same, assuming x lies in support
+// . monai::interpolation::bounds     -> min/max nodes
+
+// NOTE:
+// 1st derivatives used to be implemented with a recursive call, e.g.:
+// scalar_t grad2(scalar_t x) {
+//   if (x < 0) return -grad2(-x);
+//   ...
+// }
+// However, this prevents nvcc to statically determine the stack size
+// and leads to memory errors (because the allocated stack is too small).
+// I now use a slightly less compact implementation that gets rid of
+// recursive calls.
+
+// TODO:
+// . second order derivatives [5/6/7]
+// ? other types of basis functions (gauss, sinc)
+
+#include "utils/resample_utils.h"
+
+namespace monai {
+
+namespace _interpolation {
+
+// --- order 0 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight0(scalar_t x) {
+  x = std::fabs(x);
+  return x < 0.5 ? static_cast<scalar_t>(1) : static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight0(scalar_t x) {
+  x = std::fabs(x);
+  return static_cast<scalar_t>(1);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad0(scalar_t x) {
+  return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad0(scalar_t x) {
+  return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t hess0(scalar_t x) {
+  return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fasthess0(scalar_t x) {
+  return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds0(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::round(x));
+  upp = low;
+}
+
+// --- order 1 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight1(scalar_t x) {
+  x = std::fabs(x);
+  return x < 1 ? static_cast<scalar_t>(1) - x : static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight1(scalar_t x) {
+  return static_cast<scalar_t>(1) - std::fabs(x);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad1(scalar_t x) {
+  if (std::fabs(x) >= 1)
+    return static_cast<scalar_t>(0);
+  return fastgrad1(x);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad1(scalar_t x) {
+  return x < static_cast<scalar_t>(0) ? static_cast<scalar_t>(1) : static_cast<scalar_t>(-1);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t hess1(scalar_t x) {
+  return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fasthess1(scalar_t x) {
+  return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds1(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x));
+  upp = low + 1;
+}
+
+// --- order 2 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight2(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    return 0.75 - x * x;
+  } else if (x < 1.5) {
+    x = 1.5 - x;
+    return 0.5 * x * x;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight2(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    return 0.75 - x * x;
+  } else {
+    x = 1.5 - x;
+    return 0.5 * x * x;
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad2(scalar_t x) {
+  bool neg = x < 0;
+  if (x < 0.5) {
+    x = -2. * x;
+  } else if (x < 1.5) {
+    x = x - 1.5;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad2(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 0.5) {
+    x = -2. * x;
+  } else {
+    x = x - 1.5;
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t hess2(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    return static_cast<scalar_t>(-2.);
+  } else if (x < 1.5) {
+    return static_cast<scalar_t>(1.);
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fasthess2(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    return static_cast<scalar_t>(-2.);
+  } else {
+    return static_cast<scalar_t>(1.);
+  }
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds2(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x - .5));
+  upp = low + 2;
+}
+
+// --- order 3 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight3(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    return (x * x * (x - 2.) * 3. + 4.) / 6.;
+  } else if (x < 2.) {
+    x = 2. - x;
+    return (x * x * x) / 6.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight3(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    return (x * x * (x - 2.) * 3. + 4.) / 6.;
+  } else {
+    x = 2. - x;
+    return (x * x * x) / 6.;
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad3(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 1.) {
+    x = x * (x * 1.5 - 2.);
+  } else if (x < 2.) {
+    x = 2. - x;
+    x = -(x * x) * 0.5;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad3(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 1.) {
+    x = x * (x * 1.5 - 2.);
+  } else {
+    x = 2. - x;
+    x = -(x * x) * 0.5;
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t hess3(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    return x * 3. - 2.;
+  } else if (x < 2.) {
+    return 2. - x;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fasthess3(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    return x * 3. - 2.;
+  } else {
+    return 2. - x;
+  }
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds3(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x - 1.));
+  upp = low + 3;
+}
+
+// --- order 4 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight4(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    x *= x;
+    return x * (x * 0.25 - 0.625) + 115. / 192.;
+  } else if (x < 1.5) {
+    return x * (x * (x * (5. - x) / 6. - 1.25) + 5. / 24.) + 55. / 96.;
+  } else if (x < 2.5) {
+    x -= 2.5;
+    x *= x;
+    return (x * x) / 24.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight4(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    x *= x;
+    return x * (x * 0.25 - 0.625) + 115. / 192.;
+  } else if (x < 1.5) {
+    return x * (x * (x * (5. - x) / 6. - 1.25) + 5. / 24.) + 55. / 96.;
+  } else {
+    x -= 2.5;
+    x *= x;
+    return (x * x) / 24.;
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad4(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 0.5) {
+    x = x * (x * x - 1.25);
+  } else if (x < 1.5) {
+    x = x * (x * (x * (-2. / 3.) + 2.5) - 2.5) + 5. / 24.;
+  } else if (x < 2.5) {
+    x = x * 2. - 5.;
+    x = (x * x * x) / 48.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad4(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 0.5) {
+    x = x * (x * x - 1.25);
+  } else if (x < 1.5) {
+    x = x * (x * (x * (-2. / 3.) + 2.5) - 2.5) + 5. / 24.;
+  } else {
+    x = x * 2. - 5.;
+    x = (x * x * x) / 48.;
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t hess4(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    return (x * x) * 3. - 1.25;
+  } else if (x < 1.5) {
+    return x * (x * (-2.) + 5.) - 2.5;
+  } else if (x < 2.5) {
+    x = x * 2. - 5.;
+    return (x * x) / 8.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fasthess4(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    return (x * x) * 3. - 1.25;
+  } else if (x < 1.5) {
+    return x * (x * (-2.) + 5.) - 2.5;
+  } else {
+    x = x * 2. - 5.;
+    return (x * x) / 8.;
+  }
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds4(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x - 1.5));
+  upp = low + 4;
+}
+
+// --- order 5 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight5(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    scalar_t f = x * x;
+    return f * (f * (0.25 - x * (1. / 12.)) - 0.5) + 0.55;
+  } else if (x < 2.) {
+    return x * (x * (x * (x * (x * (1. / 24.) - 0.375) + 1.25) - 1.75) + 0.625) + 0.425;
+  } else if (x < 3.) {
+    scalar_t f = 3. - x;
+    x = f * f;
+    return f * x * x * (1. / 120.);
+  } else
+    return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight5(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    scalar_t f = x * x;
+    return f * (f * (0.25 - x * (1. / 12.)) - 0.5) + 0.55;
+  } else if (x < 2.) {
+    return x * (x * (x * (x * (x * (1. / 24.) - 0.375) + 1.25) - 1.75) + 0.625) + 0.425;
+  } else {
+    scalar_t f = 3. - x;
+    x = f * f;
+    return f * x * x * (1. / 120.);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad5(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 1.) {
+    x = x * (x * (x * (x * (-5. / 12.) + 1.)) - 1.);
+  } else if (x < 2.) {
+    x = x * (x * (x * (x * (5. / 24.) - 1.5) + 3.75) - 3.5) + 0.625;
+  } else if (x < 3.) {
+    x -= 3.;
+    x *= x;
+    x = -(x * x) / 24.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad5(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 1.) {
+    x = x * (x * (x * (x * (-5. / 12.) + 1.)) - 1.);
+  } else if (x < 2.) {
+    x = x * (x * (x * (x * (5. / 24.) - 1.5) + 3.75) - 3.5) + 0.625;
+  } else {
+    x -= 3.;
+    x *= x;
+    x = -(x * x) / 24.;
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds5(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x - 2.));
+  upp = low + 5;
+}
+
+// --- order 6 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight6(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    x *= x;
+    return x * (x * (7. / 48. - x * (1. / 36.)) - 77. / 192.) + 5887. / 11520.0;
+  } else if (x < 1.5) {
+    return x * (x * (x * (x * (x * (x * (1. / 48.) - 7. / 48.) + 0.328125) - 35. / 288.) - 91. / 256.) - 7. / 768.) +
+        7861. / 15360.0;
+  } else if (x < 2.5) {
+    return x * (x * (x * (x * (x * (7. / 60. - x * (1. / 120.)) - 0.65625) + 133. / 72.) - 2.5703125) + 1267. / 960.) +
+        1379. / 7680.0;
+  } else if (x < 3.5) {
+    x -= 3.5;
+    x *= x * x;
+    return x * x * (1. / 720.);
+  } else
+    return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight6(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 0.5) {
+    x *= x;
+    return x * (x * (7. / 48. - x * (1. / 36.)) - 77. / 192.) + 5887. / 11520.0;
+  } else if (x < 1.5) {
+    return x * (x * (x * (x * (x * (x * (1. / 48.) - 7. / 48.) + 0.328125) - 35. / 288.) - 91. / 256.) - 7. / 768.) +
+        7861. / 15360.0;
+  } else if (x < 2.5) {
+    return x * (x * (x * (x * (x * (7. / 60. - x * (1. / 120.)) - 0.65625) + 133. / 72.) - 2.5703125) + 1267. / 960.) +
+        1379. / 7680.0;
+  } else {
+    x -= 3.5;
+    x *= x * x;
+    return x * x * (1. / 720.);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad6(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < .5) {
+    scalar_t x2 = x * x;
+    x = x * (x2 * (7. / 12.) - (x2 * x2) / 6. - 77. / 96.);
+  } else if (x < 1.5) {
+    x = x * (x * (x * (x * (x * 0.125 - 35. / 48.) + 1.3125) - 35. / 96.) - 0.7109375) - 7.0 / 768.0;
+  } else if (x < 2.5) {
+    x = x * (x * (x * (x * (x * (-1. / 20.) + 7. / 12.) - 2.625) + 133. / 24.) - 5.140625) + 1267. / 960.;
+  } else if (x < 3.5) {
+    x *= 2.;
+    x -= 7.;
+    scalar_t x2 = x * x;
+    x = (x2 * x2 * x) / 3840.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad6(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < .5) {
+    scalar_t x2 = x * x;
+    x = x * (x2 * (7. / 12.) - (x2 * x2) / 6. - 77. / 96.);
+  } else if (x < 1.5) {
+    x = x * (x * (x * (x * (x * 0.125 - 35. / 48.) + 1.3125) - 35. / 96.) - 0.7109375) - 7.0 / 768.0;
+  } else if (x < 2.5) {
+    x = x * (x * (x * (x * (x * (-1. / 20.) + 7. / 12.) - 2.625) + 133. / 24.) - 5.140625) + 1267. / 960.;
+  } else {
+    x *= 2.;
+    x -= 7.;
+    scalar_t x2 = x * x;
+    x = (x2 * x2 * x) / 3840.;
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds6(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x - 2.5));
+  upp = low + 6;
+}
+
+// --- order 7 -------------------------------------------------------
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight7(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    scalar_t f = x * x;
+    return f * (f * (f * (x * (1. / 144.) - 1. / 36.) + 1. / 9.) - 1. / 3.) + 151. / 315.0;
+  } else if (x < 2.) {
+    return x * (x * (x * (x * (x * (x * (0.05 - x * (1. / 240.)) - 7. / 30.) + 0.5) - 7. / 18.) - 0.1) - 7. / 90.) +
+        103. / 210.0;
+  } else if (x < 3.) {
+    return x *
+        (x * (x * (x * (x * (x * (x * (1. / 720.) - 1. / 36.) + 7. / 30.) - 19. / 18.) + 49. / 18.) - 23. / 6.) +
+         217. / 90.) -
+        139. / 630.0;
+  } else if (x < 4.) {
+    scalar_t f = 4. - x;
+    x = f * f * f;
+    return (x * x * f) / 5040.;
+  } else
+    return static_cast<scalar_t>(0);
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight7(scalar_t x) {
+  x = std::fabs(x);
+  if (x < 1.) {
+    scalar_t f = x * x;
+    return f * (f * (f * (x * (1. / 144.) - 1. / 36.) + 1. / 9.) - 1. / 3.) + 151. / 315.0;
+  } else if (x < 2.) {
+    return x * (x * (x * (x * (x * (x * (0.05 - x * (1. / 240.)) - 7. / 30.) + 0.5) - 7. / 18.) - 0.1) - 7. / 90.) +
+        103. / 210.0;
+  } else if (x < 3.) {
+    return x *
+        (x * (x * (x * (x * (x * (x * (1. / 720.) - 1. / 36.) + 7. / 30.) - 19. / 18.) + 49. / 18.) - 23. / 6.) +
+         217. / 90.) -
+        139. / 630.0;
+  } else {
+    scalar_t f = 4. - x;
+    x = f * f * f;
+    return (x * x * f) / 5040.;
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad7(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 1.) {
+    scalar_t x2 = x * x;
+    x = x * (x2 * (x2 * (x * (7. / 144.) - 1. / 6.) + 4. / 9.) - 2. / 3.);
+  } else if (x < 2.) {
+    x = x * (x * (x * (x * (x * (x * (-7. / 240.) + 3. / 10.) - 7. / 6.) + 2.) - 7. / 6.) - 1. / 5.) - 7. / 90.;
+  } else if (x < 3.) {
+    x = x * (x * (x * (x * (x * (x * (7. / 720.) - 1. / 6.) + 7. / 6.) - 38. / 9.) + 49. / 6.) - 23. / 3.) + 217. / 90.;
+  } else if (x < 4.) {
+    x -= 4;
+    x *= x * x;
+    x *= x;
+    x = -x / 720.;
+  } else {
+    return static_cast<scalar_t>(0);
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad7(scalar_t x) {
+  bool neg = x < 0;
+  if (neg)
+    x = -x;
+  if (x < 1.) {
+    scalar_t x2 = x * x;
+    x = x * (x2 * (x2 * (x * (7. / 144.) - 1. / 6.) + 4. / 9.) - 2. / 3.);
+  } else if (x < 2.) {
+    x = x * (x * (x * (x * (x * (x * (-7. / 240.) + 3. / 10.) - 7. / 6.) + 2.) - 7. / 6.) - 1. / 5.) - 7. / 90.;
+  } else if (x < 3.) {
+    x = x * (x * (x * (x * (x * (x * (7. / 720.) - 1. / 6.) + 7. / 6.) - 38. / 9.) + 49. / 6.) - 23. / 3.) + 217. / 90.;
+  } else {
+    x -= 4;
+    x *= x * x;
+    x *= x;
+    x = -x / 720.;
+  }
+  if (neg)
+    x = -x;
+  return x;
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds7(scalar_t x, offset_t& low, offset_t& upp) {
+  low = static_cast<offset_t>(std::floor(x - 3.));
+  upp = low + 7;
+}
+
+} // namespace _interpolation
+
+namespace interpolation {
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t weight(InterpolationType interpolation_type, scalar_t x) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::weight0(x);
+    case InterpolationType::Linear:
+      return _interpolation::weight1(x);
+    case InterpolationType::Quadratic:
+      return _interpolation::weight2(x);
+    case InterpolationType::Cubic:
+      return _interpolation::weight3(x);
+    case InterpolationType::FourthOrder:
+      return _interpolation::weight4(x);
+    case InterpolationType::FifthOrder:
+      return _interpolation::weight5(x);
+    case InterpolationType::SixthOrder:
+      return _interpolation::weight6(x);
+    case InterpolationType::SeventhOrder:
+      return _interpolation::weight7(x);
+    default:
+      return _interpolation::weight1(x);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastweight(InterpolationType interpolation_type, scalar_t x) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::fastweight0(x);
+    case InterpolationType::Linear:
+      return _interpolation::fastweight1(x);
+    case InterpolationType::Quadratic:
+      return _interpolation::fastweight2(x);
+    case InterpolationType::Cubic:
+      return _interpolation::fastweight3(x);
+    case InterpolationType::FourthOrder:
+      return _interpolation::fastweight4(x);
+    case InterpolationType::FifthOrder:
+      return _interpolation::fastweight5(x);
+    case InterpolationType::SixthOrder:
+      return _interpolation::fastweight6(x);
+    case InterpolationType::SeventhOrder:
+      return _interpolation::fastweight7(x);
+    default:
+      return _interpolation::fastweight1(x);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t grad(InterpolationType interpolation_type, scalar_t x) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::grad0(x);
+    case InterpolationType::Linear:
+      return _interpolation::grad1(x);
+    case InterpolationType::Quadratic:
+      return _interpolation::grad2(x);
+    case InterpolationType::Cubic:
+      return _interpolation::grad3(x);
+    case InterpolationType::FourthOrder:
+      return _interpolation::grad4(x);
+    case InterpolationType::FifthOrder:
+      return _interpolation::grad5(x);
+    case InterpolationType::SixthOrder:
+      return _interpolation::grad6(x);
+    case InterpolationType::SeventhOrder:
+      return _interpolation::grad7(x);
+    default:
+      return _interpolation::grad1(x);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fastgrad(InterpolationType interpolation_type, scalar_t x) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::fastgrad0(x);
+    case InterpolationType::Linear:
+      return _interpolation::fastgrad1(x);
+    case InterpolationType::Quadratic:
+      return _interpolation::fastgrad2(x);
+    case InterpolationType::Cubic:
+      return _interpolation::fastgrad3(x);
+    case InterpolationType::FourthOrder:
+      return _interpolation::fastgrad4(x);
+    case InterpolationType::FifthOrder:
+      return _interpolation::fastgrad5(x);
+    case InterpolationType::SixthOrder:
+      return _interpolation::fastgrad6(x);
+    case InterpolationType::SeventhOrder:
+      return _interpolation::fastgrad7(x);
+    default:
+      return _interpolation::fastgrad1(x);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t hess(InterpolationType interpolation_type, scalar_t x) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::hess0(x);
+    case InterpolationType::Linear:
+      return _interpolation::hess1(x);
+    case InterpolationType::Quadratic:
+      return _interpolation::hess2(x);
+    case InterpolationType::Cubic:
+      return _interpolation::hess3(x);
+    case InterpolationType::FourthOrder:
+      return _interpolation::hess4(x);
+    case InterpolationType::FifthOrder:
+      return _interpolation::hess0(x); // notimplemented
+    case InterpolationType::SixthOrder:
+      return _interpolation::hess0(x); // notimplemented
+    case InterpolationType::SeventhOrder:
+      return _interpolation::hess0(x); // notimplemented
+    default:
+      return _interpolation::grad1(x);
+  }
+}
+
+template <typename scalar_t>
+static MONAI_INLINE MONAI_DEVICE scalar_t fasthess(InterpolationType interpolation_type, scalar_t x) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::fasthess0(x);
+    case InterpolationType::Linear:
+      return _interpolation::fasthess1(x);
+    case InterpolationType::Quadratic:
+      return _interpolation::fasthess2(x);
+    case InterpolationType::Cubic:
+      return _interpolation::fasthess3(x);
+    case InterpolationType::FourthOrder:
+      return _interpolation::fasthess4(x);
+    case InterpolationType::FifthOrder:
+      return _interpolation::fasthess0(x); // notimplemented
+    case InterpolationType::SixthOrder:
+      return _interpolation::fasthess0(x); // notimplemented
+    case InterpolationType::SeventhOrder:
+      return _interpolation::fasthess0(x); // notimplemented
+    default:
+      return _interpolation::fasthess1(x);
+  }
+}
+
+template <typename scalar_t, typename offset_t>
+static MONAI_INLINE MONAI_DEVICE void bounds(
+    InterpolationType interpolation_type,
+    scalar_t x,
+    offset_t& low,
+    offset_t& upp) {
+  switch (interpolation_type) {
+    case InterpolationType::Nearest:
+      return _interpolation::bounds0(x, low, upp);
+    case InterpolationType::Linear:
+      return _interpolation::bounds1(x, low, upp);
+    case InterpolationType::Quadratic:
+      return _interpolation::bounds2(x, low, upp);
+    case InterpolationType::Cubic:
+      return _interpolation::bounds3(x, low, upp);
+    case InterpolationType::FourthOrder:
+      return _interpolation::bounds4(x, low, upp);
+    case InterpolationType::FifthOrder:
+      return _interpolation::bounds5(x, low, upp);
+    case InterpolationType::SixthOrder:
+      return _interpolation::bounds6(x, low, upp);
+    case InterpolationType::SeventhOrder:
+      return _interpolation::bounds7(x, low, upp);
+    default:
+      return _interpolation::bounds1(x, low, upp);
+  }
+}
+
+} // namespace interpolation
+
+} // namespace monai

--- a/monai/csrc/resample/pushpull.h
+++ b/monai/csrc/resample/pushpull.h
@@ -1,0 +1,505 @@
+/*
+Copyright 2020 MONAI Consortium
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// adapted from https://github.com/balbasty/nitorch
+
+#include <ATen/ATen.h>
+#include <deque>
+#include <tuple>
+#include <vector>
+#include "utils/common_utils.h"
+#include "utils/resample_utils.h"
+
+#define MONAI_PUSHPULL_DECLARE(space)                                            \
+  namespace space {                                                              \
+  template <typename BoundType, typename InterpolationType, typename SourceType> \
+  std::deque<at::Tensor> pushpull(                                               \
+      const SourceType& source,                                                  \
+      const at::Tensor& grid,                                                    \
+      BoundType bound,                                                           \
+      InterpolationType interpolation,                                           \
+      bool extrapolate,                                                          \
+      bool do_pull,                                                              \
+      bool do_push,                                                              \
+      bool do_count,                                                             \
+      bool do_grad,                                                              \
+      bool do_sgrad);                                                            \
+  template <typename BoundType, typename InterpolationType, typename SourceType> \
+  std::deque<at::Tensor> pushpull(                                               \
+      const SourceType& source,                                                  \
+      const at::Tensor& grid,                                                    \
+      const at::Tensor& target,                                                  \
+      BoundType bound,                                                           \
+      InterpolationType interpolation,                                           \
+      bool extrapolate,                                                          \
+      bool do_pull,                                                              \
+      bool do_push,                                                              \
+      bool do_count,                                                             \
+      bool do_grad,                                                              \
+      bool do_sgrad);                                                            \
+  }
+
+namespace monai {
+
+MONAI_PUSHPULL_DECLARE(cpu)
+MONAI_PUSHPULL_DECLARE(cuda)
+
+// PULL
+at::Tensor grid_pull(
+    const at::Tensor& input,
+    const at::Tensor& grid,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  CHECK_DEFINED(input)
+  CHECK_DEFINED(grid)
+  auto input_opt = input.options();
+  auto grid_opt = grid.options();
+  CHECK_STRIDED(input_opt)
+  CHECK_STRIDED(grid_opt)
+  CHECK_SAME_DEVICE(input_opt, grid_opt)
+  CHECK_SAME_DTYPE(input_opt, grid_opt)
+  CHECK_SPATIAL_2D_OR_3D(input)
+  CHECK_SPATIAL_2D_OR_3D(grid)
+  CHECK_GRID_COMPONENT(grid, grid.dim())
+  CHECK_SPATIAL_NOT_EMPTY(input)
+  CHECK_SPATIAL_NOT_EMPTY(grid)
+  CHECK_VEC_NOT_EMPTY(bound_mode);
+  CHECK_VEC_NOT_EMPTY(interpolation_mode);
+
+  if (input.is_cuda())
+#ifdef WITH_CUDA
+    return cuda::pushpull(
+               input,
+               grid,
+               BoundVectorRef(bound_mode),
+               InterpolationVectorRef(interpolation_mode),
+               extrapolate,
+               true,
+               false,
+               false,
+               false,
+               false)
+        .front();
+#else
+    AT_ERROR("Not compiled with GPU support.");
+#endif
+  else
+    return cpu::pushpull(
+               input,
+               grid,
+               BoundVectorRef(bound_mode),
+               InterpolationVectorRef(interpolation_mode),
+               extrapolate,
+               true,
+               false,
+               false,
+               false,
+               false)
+        .front();
+}
+
+std::deque<at::Tensor> grid_pull_backward(
+    const at::Tensor& grad,
+    const at::Tensor& input,
+    const at::Tensor& grid,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  if (input.is_cuda()) {
+#ifdef WITH_CUDA
+    return cuda::pushpull(
+        input,
+        grid,
+        grad,
+        BoundVectorRef(bound_mode),
+        InterpolationVectorRef(interpolation_mode),
+        extrapolate,
+        false,
+        input.requires_grad(),
+        false,
+        grid.requires_grad(),
+        false);
+#else
+    AT_ERROR("Not compiled with GPU support.");
+#endif
+  } else {
+    return cpu::pushpull(
+        input,
+        grid,
+        grad,
+        BoundVectorRef(bound_mode),
+        InterpolationVectorRef(interpolation_mode),
+        extrapolate,
+        false,
+        input.requires_grad(),
+        false,
+        grid.requires_grad(),
+        false);
+  }
+}
+
+// PUSH
+at::Tensor grid_push(
+    const at::Tensor& input,
+    const at::Tensor& grid,
+    c10::IntArrayRef source_size,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  CHECK_DEFINED(input)
+  CHECK_DEFINED(grid)
+  auto input_opt = input.options();
+  auto grid_opt = grid.options();
+  CHECK_STRIDED(input_opt)
+  CHECK_STRIDED(grid_opt)
+  CHECK_SAME_DEVICE(input_opt, grid_opt)
+  CHECK_SAME_DTYPE(input_opt, grid_opt)
+  CHECK_SPATIAL_2D_OR_3D(input)
+  CHECK_SPATIAL_2D_OR_3D(grid)
+  CHECK_GRID_COMPONENT(grid, grid.dim())
+  CHECK_SPATIAL_NOT_EMPTY(input)
+  CHECK_SPATIAL_NOT_EMPTY(grid)
+  CHECK_GRID_TARGET_COMPAT(grid, input)
+  CHECK_VEC_NOT_EMPTY(bound_mode);
+  CHECK_VEC_NOT_EMPTY(interpolation_mode);
+
+  if (source_size.empty()) {
+    auto size = c10::IntArrayRef({input.size(2), input.size(3), input.dim() == 5 ? input.size(4) : 1});
+    if (input.is_cuda())
+#ifdef WITH_CUDA
+      return cuda::pushpull(
+                 size,
+                 grid,
+                 input,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 true,
+                 false,
+                 false,
+                 false)
+          .front();
+#else
+      AT_ERROR("Not compiled with GPU support.");
+#endif
+    else
+      return cpu::pushpull(
+                 size,
+                 grid,
+                 input,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 true,
+                 false,
+                 false,
+                 false)
+          .front();
+  } else {
+    CHECK_SPATIAL_LENGTH(source_size, grid.dim())
+    if (input.is_cuda())
+#ifdef WITH_CUDA
+      return cuda::pushpull(
+                 source_size,
+                 grid,
+                 input,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 true,
+                 false,
+                 false,
+                 false)
+          .front();
+#else
+      AT_ERROR("Not compiled with GPU support.");
+#endif
+    else
+      return cpu::pushpull(
+                 source_size,
+                 grid,
+                 input,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 true,
+                 false,
+                 false,
+                 false)
+          .front();
+  }
+}
+
+std::deque<at::Tensor> grid_push_backward(
+    const at::Tensor& grad,
+    const at::Tensor& input,
+    const at::Tensor& grid,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  if (input.is_cuda()) {
+#ifdef WITH_CUDA
+    return cuda::pushpull(
+        grad,
+        grid,
+        input,
+        BoundVectorRef(bound_mode),
+        InterpolationVectorRef(interpolation_mode),
+        extrapolate,
+        input.requires_grad(),
+        false,
+        false,
+        grid.requires_grad(),
+        false);
+#else
+    AT_ERROR("Not compiled with GPU support.");
+#endif
+  } else {
+    return cpu::pushpull(
+        grad,
+        grid,
+        input,
+        BoundVectorRef(bound_mode),
+        InterpolationVectorRef(interpolation_mode),
+        extrapolate,
+        input.requires_grad(),
+        false,
+        false,
+        grid.requires_grad(),
+        false);
+  }
+}
+
+// COUNT
+at::Tensor grid_count(
+    const at::Tensor& grid,
+    c10::IntArrayRef source_size,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  CHECK_DEFINED(grid)
+  auto grid_opt = grid.options();
+  CHECK_STRIDED(grid_opt)
+  CHECK_SPATIAL_2D_OR_3D(grid)
+  CHECK_GRID_COMPONENT(grid, grid.dim())
+  CHECK_SPATIAL_NOT_EMPTY(grid)
+  CHECK_VEC_NOT_EMPTY(bound_mode);
+  CHECK_VEC_NOT_EMPTY(interpolation_mode);
+
+  if (source_size.empty()) {
+    auto size = c10::IntArrayRef({grid.size(1), grid.size(2), grid.dim() == 5 ? grid.size(3) : 1});
+    if (grid.is_cuda())
+#ifdef WITH_CUDA
+      return cuda::pushpull(
+                 size,
+                 grid,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 false,
+                 true,
+                 false,
+                 false)
+          .front();
+#else
+      AT_ERROR("Not compiled with GPU support.");
+#endif
+    else
+      return cpu::pushpull(
+                 size,
+                 grid,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 false,
+                 true,
+                 false,
+                 false)
+          .front();
+  } else {
+    CHECK_SPATIAL_LENGTH(source_size, grid.dim())
+    if (grid.is_cuda())
+#ifdef WITH_CUDA
+      return cuda::pushpull(
+                 source_size,
+                 grid,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 false,
+                 true,
+                 false,
+                 false)
+          .front();
+#else
+      AT_ERROR("Not compiled with GPU support.");
+#endif
+    else
+      return cpu::pushpull(
+                 source_size,
+                 grid,
+                 BoundVectorRef(bound_mode),
+                 InterpolationVectorRef(interpolation_mode),
+                 extrapolate,
+                 false,
+                 false,
+                 true,
+                 false,
+                 false)
+          .front();
+  }
+}
+
+at::Tensor grid_count_backward(
+    const at::Tensor& grad,
+    const at::Tensor& grid,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  if (grid.is_cuda()) {
+#ifdef WITH_CUDA
+    return cuda::pushpull(
+               grad,
+               grid,
+               BoundVectorRef(bound_mode),
+               InterpolationVectorRef(interpolation_mode),
+               extrapolate,
+               false,
+               false,
+               false,
+               grid.requires_grad(),
+               false)
+        .front();
+#else
+    AT_ERROR("Not compiled with GPU support.");
+#endif
+  } else {
+    return cpu::pushpull(
+               grad,
+               grid,
+               BoundVectorRef(bound_mode),
+               InterpolationVectorRef(interpolation_mode),
+               extrapolate,
+               false,
+               false,
+               false,
+               grid.requires_grad(),
+               false)
+        .front();
+  }
+}
+
+// PULL GRADIENTS
+at::Tensor grid_grad(
+    const at::Tensor& input,
+    const at::Tensor& grid,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  CHECK_DEFINED(input)
+  CHECK_DEFINED(grid)
+  auto input_opt = input.options();
+  auto grid_opt = grid.options();
+  CHECK_STRIDED(input_opt)
+  CHECK_STRIDED(grid_opt)
+  CHECK_SAME_DEVICE(input_opt, grid_opt)
+  CHECK_SAME_DTYPE(input_opt, grid_opt)
+  CHECK_SPATIAL_2D_OR_3D(input)
+  CHECK_SPATIAL_2D_OR_3D(grid)
+  CHECK_GRID_COMPONENT(grid, grid.dim())
+  CHECK_SPATIAL_NOT_EMPTY(input)
+  CHECK_SPATIAL_NOT_EMPTY(grid)
+  CHECK_VEC_NOT_EMPTY(bound_mode);
+  CHECK_VEC_NOT_EMPTY(interpolation_mode);
+
+  if (input.is_cuda())
+#ifdef WITH_CUDA
+    return cuda::pushpull(
+               input,
+               grid,
+               BoundVectorRef(bound_mode),
+               InterpolationVectorRef(interpolation_mode),
+               extrapolate,
+               false,
+               false,
+               false,
+               false,
+               true)
+        .front();
+#else
+    AT_ERROR("Not compiled with GPU support.");
+#endif
+  else
+    return cpu::pushpull(
+               input,
+               grid,
+               BoundVectorRef(bound_mode),
+               InterpolationVectorRef(interpolation_mode),
+               extrapolate,
+               false,
+               false,
+               false,
+               false,
+               true)
+        .front();
+}
+
+std::deque<at::Tensor> grid_grad_backward(
+    const at::Tensor& grad,
+    const at::Tensor& input,
+    const at::Tensor& grid,
+    const std::vector<BoundType>& bound_mode,
+    const std::vector<InterpolationType>& interpolation_mode,
+    bool extrapolate) {
+  if (input.is_cuda()) {
+#ifdef WITH_CUDA
+    return cuda::pushpull(
+        input,
+        grid,
+        grad,
+        BoundVectorRef(bound_mode),
+        InterpolationVectorRef(interpolation_mode),
+        extrapolate,
+        false,
+        input.requires_grad(),
+        false,
+        grid.requires_grad(),
+        false);
+#else
+    AT_ERROR("Not compiled with GPU support.");
+#endif
+  } else {
+    return cpu::pushpull(
+        input,
+        grid,
+        grad,
+        BoundVectorRef(bound_mode),
+        InterpolationVectorRef(interpolation_mode),
+        extrapolate,
+        false,
+        input.requires_grad(),
+        false,
+        grid.requires_grad(),
+        false);
+  }
+}
+
+} // namespace monai

--- a/monai/csrc/resample/pushpull_cpu.cpp
+++ b/monai/csrc/resample/pushpull_cpu.cpp
@@ -1,0 +1,1801 @@
+/*
+Copyright 2020 MONAI Consortium
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// adapted from https://github.com/balbasty/nitorch
+
+// This file implements spline interpolation / sampling and its adjoint
+// operations. It corresponds loosely to torch's `GridSampler`.
+// It handles boundary conditions and interpolation orders defined in
+// `utils/resample_utils.h` and `utils/resample_utils.h`.
+// These parameters can be specified per dimension.
+// Isotorpic 0-th and 1-st order interpolation have their own (faster)
+// implementations. Sliding boundary conditions are also implemented
+// separately.
+
+// TODO:
+// . [DONE] generic 3d
+// . [DONE] generic 2d
+// . sliding nearest 3d
+// . sliding nearest 2d
+// . sliding linear 3d
+// . sliding linear 2d
+// . slinding generic 3d
+// . sliding generic 2d
+// . [DONE] spatial gradient mode (without mutliplication with output gradient)
+// . [DONE] second order gradients (backward pass for spatial gradients)
+// . performance tests
+// . input bound/inter are always vectors -> clean unused constructors
+
+#include <ATen/ATen.h>
+#include <tuple>
+#include "bounds_common.h"
+#include "interpolation_common.h"
+#include "utils/resample_utils.h"
+//#include <cstdio>
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CPU/GPU -specific parameters
+#include <ATen/Parallel.h>
+namespace {
+// This parameter specifies the minimum number of voxels that should be
+// processed on a single processor in the parallel for loop .
+int64_t GRAIN_SIZE = static_cast<int64_t>(at::internal::GRAIN_SIZE);
+} // namespace
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// maximum number of channels
+// > not used in mode isotropic nearest/linear
+#ifndef MONAI_MAX_NUM_CHANNELS
+#define MONAI_MAX_NUM_CHANNELS 1024
+#endif
+
+// This parameter allows for a little bit of tolerance when considering
+// a coordinate as "out-of-bound" (if !extrapolate)
+#define TINY 5e-2
+
+using at::Tensor;
+using at::TensorOptions;
+using c10::IntArrayRef;
+
+namespace monai {
+MONAI_NAMESPACE_DEVICE { // cpu
+
+  namespace { // anonymous namespace > everything inside has internal linkage
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                        GENERIC PUSHPULL CLASS
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // This class implements the bulk of the code.
+  // /!\ No type and shape checking is performed here.
+
+  template <typename scalar_t, typename offset_t>
+  class PushPullImpl {
+   public:
+    // ~~~ CONSTRUCTORS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundVectorRef bound,
+        InterpolationVectorRef interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound1(bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound2(
+              bound.size() > 2 ? bound[2]
+                               : bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          interpolation0(interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation1(
+              interpolation.size() > 1 ? interpolation[1]
+                                       : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation2(
+              interpolation.size() > 2
+                  ? interpolation[2]
+                  : interpolation.size() > 1 ? interpolation[1]
+                                             : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundType bound,
+        InterpolationVectorRef interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound),
+          bound1(bound),
+          bound2(bound),
+          interpolation0(interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation1(
+              interpolation.size() > 1 ? interpolation[1]
+                                       : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation2(
+              interpolation.size() > 2
+                  ? interpolation[2]
+                  : interpolation.size() > 1 ? interpolation[1]
+                                             : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundVectorRef bound,
+        InterpolationType interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound1(bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound2(
+              bound.size() > 2 ? bound[2]
+                               : bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          interpolation0(interpolation),
+          interpolation1(interpolation),
+          interpolation2(interpolation),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundType bound,
+        InterpolationType interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound),
+          bound1(bound),
+          bound2(bound),
+          interpolation0(interpolation),
+          interpolation1(interpolation),
+          interpolation2(interpolation),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    // ~~~ PUBLIC VALUE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    std::deque<Tensor> output;
+
+    // MONAI_HOST MONAI_DEVICE void printInfo() const {
+    //   printf("dim: %d\n", dim);
+    //   printf("do_pull:  %d\n", do_pull);
+    //   printf("do_push:  %d\n", do_push);
+    //   printf("do_count: %d\n", do_count);
+    //   printf("do_sgrad: %d\n", do_sgrad);
+    //   printf("do_grad:  %d\n", do_grad);
+    //   printf("bound:         [%d %d %d]\n", static_cast<int>(bound0),
+    //     static_cast<int>(bound1), static_cast<int>(bound2));
+    //   printf("interpolation: [%d %d %d]\n", static_cast<int>(interpolation0),
+    //     static_cast<int>(interpolation1), static_cast<int>(interpolation2));
+    //   printf("src:  [%d %d %d]\n", src_Z, src_Y, src_X);
+    //   printf("trgt: [%d %d %d (%d)]\n", trgt_Z, trgt_Y, trgt_X, trgt_K);
+    //   printf("N: %d\n", N);
+    //   printf("C: %d\n", C);
+    //   printf("src  -> %lu\n", reinterpret_cast<std::uintptr_t>(src_ptr));
+    //   printf("trgt -> %lu\n", reinterpret_cast<std::uintptr_t>(trgt_ptr));
+    //   printf("grid -> %lu\n", reinterpret_cast<std::uintptr_t>(grid_ptr));
+    //   printf("out  -> %lu\n", reinterpret_cast<std::uintptr_t>(out_ptr));
+    //   printf("grad -> %lu\n", reinterpret_cast<std::uintptr_t>(grad_ptr));
+    // }
+
+    // ~~~ FUNCTORS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    MONAI_HOST void ioset // Pull
+        (const Tensor& source, const Tensor& grid) {
+      init_all();
+      init_source(source);
+      init_grid(grid);
+      init_output();
+    }
+
+    MONAI_HOST void ioset(const Tensor& source, const Tensor& grid, const Tensor& target) {
+      init_all();
+      init_source(source);
+      init_grid(grid);
+      init_target(target);
+      init_output();
+    }
+
+    MONAI_HOST void ioset // Push
+        (IntArrayRef source_size, const Tensor& grid, const Tensor& target) {
+      init_all();
+      init_source(source_size);
+      init_grid(grid);
+      init_target(target);
+      init_output();
+    }
+
+    MONAI_HOST void ioset // Count
+        (IntArrayRef source_size, const Tensor& grid) {
+      init_all();
+      init_source(source_size);
+      init_grid(grid);
+      init_output();
+    }
+
+    void loop() const;
+
+    MONAI_HOST MONAI_DEVICE int64_t voxcount() const {
+      return N * trgt_X * trgt_Y * trgt_Z;
+    }
+
+   private:
+    // ~~~ COMPONENTS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    MONAI_HOST void init_all();
+    MONAI_HOST void init_source(const Tensor& source);
+    MONAI_HOST void init_source(IntArrayRef source_size);
+    MONAI_HOST void init_grid(const Tensor& grid);
+    MONAI_HOST void init_target(const Tensor& target);
+    MONAI_HOST void init_output();
+    MONAI_DEVICE void check2d(offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void check3d(offset_t w, offset_t h, offset_t d, offset_t n) const;
+    MONAI_DEVICE void interpolate2d(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void interpolate2d_nearest(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void interpolate2d_bilinear(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void interpolate2d_sliding(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate2d_sliding_nearest(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n)
+        const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate2d_sliding_bilinear(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n)
+        const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate3d(scalar_t x, scalar_t y, scalar_t z, offset_t w, offset_t h, offset_t d, offset_t n)
+        const;
+    MONAI_DEVICE void interpolate3d_nearest(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const;
+    MONAI_DEVICE void interpolate3d_trilinear(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const;
+    MONAI_DEVICE void interpolate3d_sliding(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate3d_sliding_nearest(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate3d_sliding_trilinear(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const { /*TODO*/
+    }
+
+    // ~~~ OPTIONS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    int dim; // dimensionality (2 or 3)
+    BoundType bound0; // boundary condition  // x|W
+    BoundType bound1; // boundary condition  // y|H
+    BoundType bound2; // boundary condition  // z|D
+    InterpolationType interpolation0; // interpolation order // x|W
+    InterpolationType interpolation1; // interpolation order // y|H
+    InterpolationType interpolation2; // interpolation order // z|D
+    bool iso; // isotropic interpolation?
+    bool extrapolate; // compute out-of-bound values
+    bool do_pull; // sample a volume
+    bool do_push; // splat a volume
+    bool do_count; // splatting weights (= jacobian determinant)
+    bool do_grad; // backprop: gradient of grid // pull
+    bool do_sgrad; // sample spatial gradients
+
+    // ~~~ NAVIGATORS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    TensorOptions src_opt;
+    TensorOptions grid_opt;
+    TensorOptions trgt_opt;
+    offset_t N;
+    offset_t C;
+    offset_t src_X;
+    offset_t src_Y;
+    offset_t src_Z;
+    offset_t trgt_X;
+    offset_t trgt_Y;
+    offset_t trgt_Z;
+    offset_t trgt_K;
+    offset_t src_sN;
+    offset_t src_sC;
+    offset_t src_sX;
+    offset_t src_sY;
+    offset_t src_sZ;
+    scalar_t* src_ptr;
+    offset_t trgt_sN;
+    offset_t trgt_sC;
+    offset_t trgt_sX;
+    offset_t trgt_sY;
+    offset_t trgt_sZ;
+    offset_t trgt_sK;
+    scalar_t* trgt_ptr;
+    offset_t grid_sN;
+    offset_t grid_sC;
+    offset_t grid_sX;
+    offset_t grid_sY;
+    offset_t grid_sZ;
+    scalar_t* grid_ptr;
+    offset_t out_sN;
+    offset_t out_sC;
+    offset_t out_sX;
+    offset_t out_sY;
+    offset_t out_sZ;
+    offset_t out_sK; // gradient dimension
+    scalar_t* out_ptr;
+    offset_t grad_sN;
+    offset_t grad_sC;
+    offset_t grad_sX;
+    offset_t grad_sY;
+    offset_t grad_sZ;
+    scalar_t* grad_ptr;
+  };
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                          INITIALISATION
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  void PushPullImpl<scalar_t, offset_t>::init_all() {
+    src_opt = grid_opt = trgt_opt = TensorOptions();
+    N = C = static_cast<offset_t>(1);
+    src_X = src_Y = src_Z = static_cast<offset_t>(1);
+    trgt_X = trgt_Y = trgt_Z = trgt_K = static_cast<offset_t>(1);
+    src_sN = src_sC = src_sX = src_sY = src_sZ = static_cast<offset_t>(0);
+    grid_sN = grid_sC = grid_sX = grid_sY = grid_sZ = static_cast<offset_t>(0);
+    grad_sN = grad_sC = grad_sX = grad_sY = grad_sZ = static_cast<offset_t>(0);
+    trgt_sN = trgt_sC = trgt_sX = trgt_sY = trgt_sZ = trgt_sK = static_cast<offset_t>(0);
+    out_sN = out_sC = out_sX = out_sY = out_sZ = out_sK = static_cast<offset_t>(0);
+    src_ptr = trgt_ptr = grid_ptr = out_ptr = grad_ptr = static_cast<scalar_t*>(0);
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_source(const Tensor& source) {
+    N = source.size(0);
+    C = source.size(1);
+    src_X = source.size(2);
+    src_Y = source.size(3);
+    src_Z = dim == 2 ? static_cast<offset_t>(1) : source.size(4);
+    src_sN = source.stride(0);
+    src_sC = source.stride(1);
+    src_sX = source.stride(2);
+    src_sY = source.stride(3);
+    src_sZ = dim == 2 ? static_cast<offset_t>(0) : source.stride(4);
+    src_ptr = source.data_ptr<scalar_t>();
+    src_opt = source.options();
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_source(IntArrayRef source_size) {
+    src_X = source_size[0];
+    src_Y = source_size[1];
+    src_Z = dim == 2 ? static_cast<offset_t>(1) : source_size[2];
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_grid(const Tensor& grid) {
+    N = grid.size(0);
+    trgt_X = grid.size(1);
+    trgt_Y = grid.size(2);
+    trgt_Z = dim == 2 ? static_cast<offset_t>(1) : grid.size(3);
+    grid_sN = grid.stride(0);
+    grid_sX = grid.stride(1);
+    grid_sY = grid.stride(2);
+    grid_sZ = dim == 2 ? static_cast<offset_t>(0) : grid.stride(3);
+    grid_sC = grid.stride(dim == 2 ? 3 : 4);
+    grid_ptr = grid.data_ptr<scalar_t>();
+    grid_opt = grid.options();
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_target(const Tensor& target) {
+    N = target.size(0);
+    C = target.size(1);
+    trgt_X = target.size(2);
+    trgt_Y = target.size(3);
+    trgt_Z = dim == 2 ? static_cast<offset_t>(1) : target.size(4);
+    trgt_K = target.dim() == dim + 3 ? target.size(dim == 2 ? 4 : 5) : static_cast<offset_t>(1);
+    trgt_sN = target.stride(0);
+    trgt_sC = target.stride(1);
+    trgt_sX = target.stride(2);
+    trgt_sY = target.stride(3);
+    trgt_sZ = dim == 2 ? static_cast<offset_t>(0) : target.stride(4);
+    trgt_sK = target.dim() == dim + 3 ? target.stride(dim == 2 ? 4 : 5) : static_cast<offset_t>(0);
+    trgt_ptr = target.data_ptr<scalar_t>();
+    trgt_opt = target.options();
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_output() {
+    output.clear();
+    if (do_pull) {
+      if (dim == 2)
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y}, src_opt));
+      else
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y, trgt_Z}, src_opt));
+      auto pull = output.back();
+      out_sN = pull.stride(0);
+      out_sC = pull.stride(1);
+      out_sX = pull.stride(2);
+      out_sY = pull.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : pull.stride(4);
+      out_sK = static_cast<offset_t>(0);
+      out_ptr = pull.template data_ptr<scalar_t>();
+    } else if (do_sgrad) {
+      if (dim == 2)
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y, 2}, src_opt));
+      else
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y, trgt_Z, 3}, src_opt));
+      auto sgrad = output.back();
+      out_sN = sgrad.stride(0);
+      out_sC = sgrad.stride(1);
+      out_sX = sgrad.stride(2);
+      out_sY = sgrad.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : sgrad.stride(4);
+      out_sK = sgrad.stride(dim == 2 ? 4 : 5);
+      out_ptr = sgrad.template data_ptr<scalar_t>();
+
+      if (iso && interpolation0 == InterpolationType::Nearest)
+        sgrad.zero_();
+    } else if (do_push) {
+      if (dim == 2)
+        output.push_back(at::zeros({N, C, src_X, src_Y}, trgt_opt));
+      else
+        output.push_back(at::zeros({N, C, src_X, src_Y, src_Z}, trgt_opt));
+      auto push = output.back();
+      out_sN = push.stride(0);
+      out_sC = push.stride(1);
+      out_sX = push.stride(2);
+      out_sY = push.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : push.stride(4);
+      out_sK = static_cast<offset_t>(0);
+      out_ptr = push.template data_ptr<scalar_t>();
+    } else if (do_count) {
+      if (dim == 2)
+        output.push_back(at::zeros({N, 1, src_X, src_Y}, grid_opt));
+      else
+        output.push_back(at::zeros({N, 1, src_X, src_Y, src_Z}, grid_opt));
+      auto count = output.back();
+      out_sN = count.stride(0);
+      out_sC = count.stride(1);
+      out_sX = count.stride(2);
+      out_sY = count.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : count.stride(4);
+      out_sK = static_cast<offset_t>(0);
+      out_ptr = count.template data_ptr<scalar_t>();
+    }
+    if (do_grad) {
+      if (dim == 2)
+        output.push_back(at::zeros({N, src_X, src_Y, 2}, grid_opt));
+      else
+        output.push_back(at::zeros({N, src_X, src_Y, src_Z, 3}, grid_opt));
+      auto grad = output.back();
+      grad_sN = grad.stride(0);
+      grad_sX = grad.stride(1);
+      grad_sY = grad.stride(2);
+      grad_sZ = dim == 2 ? static_cast<offset_t>(0) : grad.stride(3);
+      grad_sC = grad.stride(dim == 2 ? 3 : 4);
+      grad_ptr = grad.template data_ptr<scalar_t>();
+
+      if (iso && interpolation0 == InterpolationType::Nearest)
+        grad.zero_();
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                             LOOP
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // This bit loops over all target voxels. We therefore need to
+  // convert linear indices to multivariate indices. The way I do it
+  // might not be optimal.
+  // Note that I parallelize across all voxels (wheareas ATen's grid
+  // sampler is only parallelized across batches).
+  //
+  // TODO: check that the default grain size is optimal. We do quite a lot
+  // of compute per voxel, so a smaller value might be better suited.
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::loop() const {
+#if !(AT_PARALLEL_OPENMP)
+    if (do_push) {
+      // I do not have access to atomic operations so I cannot
+      // parallelize across voxels.
+      at::parallel_for(0, N, 0, [&](offset_t start, offset_t end) {
+        for (offset_t n = start; n < end; ++n) {
+          if (dim == 2) {
+            for (offset_t h = 0; h < trgt_Y; ++h)
+              for (offset_t w = 0; w < trgt_X; ++w)
+                check2d(w, h, n);
+          } else {
+            for (offset_t d = 0; d < trgt_Z; ++d)
+              for (offset_t h = 0; h < trgt_Y; ++h)
+                for (offset_t w = 0; w < trgt_X; ++w)
+                  check3d(w, h, d, n);
+          }
+        }
+      });
+      return
+    }
+#endif
+
+    // Parallelize across voxels
+    offset_t trgt_NXYZ = trgt_Z * trgt_Y * trgt_X * N;
+    offset_t trgt_XYZ = trgt_Z * trgt_Y * trgt_X;
+    offset_t trgt_YZ = trgt_Z * trgt_Y;
+    at::parallel_for(0, trgt_NXYZ, GRAIN_SIZE, [&](offset_t start, offset_t end) {
+      offset_t n, w, h, d;
+      for (offset_t i = start; i < end; ++i) {
+        // Convert index: linear to sub
+        n = (i / trgt_XYZ);
+        w = (i / trgt_YZ) % trgt_X;
+        h = (i / trgt_Z) % trgt_Y;
+        d = i % trgt_Z;
+
+        if (dim == 2)
+          check2d(w, h, n);
+        else
+          check3d(w, h, d, n);
+      }
+    });
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                        CHECK OUT-OF-BOUND
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  // Here, we:
+  // 1) read the [x,y,z] source coordinate for the current target voxel
+  // 3) check if the source coordinate is in bounds
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::check2d(offset_t w, offset_t h, offset_t n) const {
+    // get the corresponding input x, y, z co-ordinates from grid
+    scalar_t* grid_ptr_NXY = grid_ptr + n * grid_sN + w * grid_sX + h * grid_sY;
+    scalar_t x = *grid_ptr_NXY;
+    scalar_t y = grid_ptr_NXY[grid_sC];
+
+    // Check if out-of-bound
+    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY)))) {
+      if (do_pull || do_sgrad) {
+        scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sZ + h * out_sY;
+        for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC) {
+          *out_ptr_NCXY = static_cast<scalar_t>(0);
+          if (do_sgrad)
+            out_ptr_NCXY[out_sK] = static_cast<scalar_t>(0);
+        }
+      }
+      if (do_grad) {
+        scalar_t* grad_ptr_NXY = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY;
+        (*grad_ptr_NXY) = static_cast<scalar_t>(0);
+        grad_ptr_NXY[grad_sC] = static_cast<scalar_t>(0);
+      }
+      return;
+    }
+
+    // Next step
+    if (bound0 == BoundType::Sliding) {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate2d_sliding_nearest(x, y, w, h, n);
+          case 1:
+            return interpolate2d_sliding_bilinear(x, y, w, h, n);
+        }
+      return interpolate2d_sliding(x, y, w, h, n);
+    } else {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate2d_nearest(x, y, w, h, n);
+          case 1:
+            return interpolate2d_bilinear(x, y, w, h, n);
+        }
+      return interpolate2d(x, y, w, h, n);
+    }
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::check3d(offset_t w, offset_t h, offset_t d, offset_t n) const {
+    // get the corresponding input x, y, z co-ordinates from grid
+    scalar_t* grid_ptr_NXYZ = grid_ptr + n * grid_sN + w * grid_sX + h * grid_sY + d * grid_sZ;
+    scalar_t x = *grid_ptr_NXYZ;
+    scalar_t y = grid_ptr_NXYZ[grid_sC];
+    scalar_t z = grid_ptr_NXYZ[grid_sC * 2];
+
+    // Check if out-of-bound
+    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY)) || inbounds(z, src_Z, static_cast<scalar_t>(TINY)))) {
+      if (do_pull || do_sgrad) {
+        scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+        for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC) {
+          *out_ptr_NCXYZ = static_cast<scalar_t>(0);
+          if (do_sgrad) {
+            out_ptr_NCXYZ[out_sK] = static_cast<scalar_t>(0);
+            out_ptr_NCXYZ[out_sK * 2] = static_cast<scalar_t>(0);
+          }
+        }
+      }
+      if (do_grad) {
+        scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY + d * grad_sZ;
+        (*grad_ptr_NXYZ) = static_cast<scalar_t>(0);
+        grad_ptr_NXYZ[grad_sC] = static_cast<scalar_t>(0);
+        grad_ptr_NXYZ[grad_sC * 2] = static_cast<scalar_t>(0);
+      }
+      return;
+    }
+
+    // Next step
+    if (bound0 == BoundType::Sliding) {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate3d_sliding_nearest(x, y, z, w, h, d, n);
+          case 1:
+            return interpolate3d_sliding_trilinear(x, y, z, w, h, d, n);
+        }
+      return interpolate3d_sliding(x, y, z, w, h, d, n);
+    } else {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate3d_nearest(x, y, z, w, h, d, n);
+          case 1:
+            return interpolate3d_trilinear(x, y, z, w, h, d, n);
+        }
+      return interpolate3d(x, y, z, w, h, d, n);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     GENERIC INTERPOLATION 3D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate3d(
+      scalar_t x,
+      scalar_t y,
+      scalar_t z,
+      offset_t w,
+      offset_t h,
+      offset_t d,
+      offset_t n) const {
+    // Get corner pixel values from (x, y, z)
+    offset_t bx0, bx1, by0, by1, bz0, bz1;
+    interpolation::bounds(interpolation0, x, bx0, bx1);
+    interpolation::bounds(interpolation1, y, by0, by1);
+    interpolation::bounds(interpolation2, z, bz0, bz1);
+    offset_t dbx = bx1 - bx0;
+    offset_t dby = by1 - by0;
+    offset_t dbz = bz1 - bz0;
+
+    // Pre-compute offsets and target value
+    scalar_t* src_ptr_NC0 = src_ptr + n * src_sN;
+    scalar_t* out_ptr_NC0 = out_ptr + n * out_sN;
+    scalar_t* out_ptr_NCXYZ0 = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+    scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+    scalar_t target[3 * MONAI_MAX_NUM_CHANNELS];
+    if (trgt_ptr && (do_push || do_grad))
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC) {
+        target[c] = *trgt_ptr_NCXYZ;
+        if (trgt_K > 1) {
+          target[c + C] = trgt_ptr_NCXYZ[trgt_sK];
+          target[c + C * 2] = trgt_ptr_NCXYZ[trgt_sK * 2];
+        }
+      }
+
+    // Initialize output
+    scalar_t* out_ptr_NCXYZ = out_ptr_NCXYZ0;
+    if (do_pull || do_sgrad) {
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC) {
+        *out_ptr_NCXYZ = static_cast<scalar_t>(0);
+        if (do_sgrad) {
+          out_ptr_NCXYZ[out_sK] = static_cast<scalar_t>(0);
+          out_ptr_NCXYZ[out_sK * 2] = static_cast<scalar_t>(0);
+        }
+      }
+    }
+
+    // Pre-compute indices/weights/grad
+    scalar_t wx[8], wy[8], wz[8]; // B-spline weights
+    scalar_t gx[8], gy[8], gz[8]; // B-spline derivatives
+    scalar_t hx[8], hy[8], hz[8]; // B-spline 2nd derivatives
+    offset_t ix[8], iy[8], iz[8]; // Warped indices
+    uint8_t sx[8], sy[8], sz[8]; // Warped indices
+
+    {
+      scalar_t *owz = static_cast<scalar_t*>(wz), *ogz = static_cast<scalar_t*>(gz), *ohz = static_cast<scalar_t*>(hz);
+      offset_t* oiz = static_cast<offset_t*>(iz);
+      uint8_t* osz = static_cast<uint8_t*>(sz);
+      for (offset_t bz = bz0; bz <= bz1; ++bz) {
+        scalar_t dz = z - bz;
+        *(owz++) = interpolation::fastweight(interpolation2, dz);
+        if (do_grad || do_sgrad)
+          *(ogz++) = interpolation::fastgrad(interpolation2, dz);
+        if (do_grad && trgt_sK > 1)
+          *(ohz++) = interpolation::fasthess(interpolation2, dz);
+        *(osz++) = bound::sign(bound2, bz, src_Z);
+        *(oiz++) = bound::index(bound2, bz, src_Z);
+      }
+    }
+    {
+      scalar_t *owy = static_cast<scalar_t*>(wy), *ogy = static_cast<scalar_t*>(gy), *ohy = static_cast<scalar_t*>(hy);
+      offset_t* oiy = static_cast<offset_t*>(iy);
+      uint8_t* osy = static_cast<uint8_t*>(sy);
+      for (offset_t by = by0; by <= by1; ++by) {
+        scalar_t dy = y - by;
+        *(owy++) = interpolation::fastweight(interpolation1, dy);
+        if (do_grad || do_sgrad)
+          *(ogy++) = interpolation::fastgrad(interpolation1, dy);
+        if (do_grad && trgt_sK > 1)
+          *(ohy++) = interpolation::fasthess(interpolation1, dy);
+        *(osy++) = bound::sign(bound1, by, src_Y);
+        *(oiy++) = bound::index(bound1, by, src_Y);
+      }
+    }
+    {
+      scalar_t *owx = static_cast<scalar_t*>(wx), *ogx = static_cast<scalar_t*>(gx), *ohx = static_cast<scalar_t*>(hx);
+      offset_t* oix = static_cast<offset_t*>(ix);
+      uint8_t* osx = static_cast<uint8_t*>(sx);
+      for (offset_t bx = bx0; bx <= bx1; ++bx) {
+        scalar_t dx = x - bx;
+        *(owx++) = interpolation::fastweight(interpolation0, dx);
+        if (do_grad || do_sgrad)
+          *(ogx++) = interpolation::fastgrad(interpolation0, dx);
+        if (do_grad && trgt_sK > 1)
+          *(ohx++) = interpolation::fasthess(interpolation0, dx);
+        *(osx++) = bound::sign(bound0, bx, src_X);
+        *(oix++) = bound::index(bound0, bx, src_X);
+      }
+    }
+
+    // Convolve coefficients with basis functions
+    scalar_t ogx, ogy, ogz;
+    ogx = ogy = ogz = static_cast<scalar_t>(0);
+    for (offset_t k = 0; k <= dbz; ++k) {
+      offset_t ooz = iz[k] * out_sZ;
+      offset_t osz = iz[k] * src_sZ;
+      uint8_t szz = sz[k];
+      scalar_t wzz = wz[k];
+      scalar_t gzz = gz[k];
+      scalar_t hzz = hz[k];
+      for (offset_t j = 0; j <= dby; ++j) {
+        offset_t ooyz = ooz + iy[j] * out_sY;
+        offset_t osyz = osz + iy[j] * src_sY;
+        uint8_t syz = szz * sy[j];
+        scalar_t wyy = wy[j];
+        scalar_t gyy = gy[j];
+        scalar_t hyy = hy[j];
+        for (offset_t i = 0; i <= dbx; ++i) {
+          offset_t ooxyz = ooyz + ix[i] * out_sX;
+          offset_t osxyz = osyz + ix[i] * src_sX;
+          uint8_t sxyz = syz * sx[i];
+          scalar_t wxx = wx[i];
+          scalar_t gxx = gx[i];
+          scalar_t hxx = hx[i];
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          if (do_pull) {
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t* out_ptr_NCXYZ = out_ptr_NCXYZ0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC)
+              *out_ptr_NCXYZ += bound::get(src_ptr_NC, osxyz, sxyz) * (wxx * wyy * wzz);
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          else if (do_sgrad) {
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t* out_ptr_NCXYZ = out_ptr_NCXYZ0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
+              scalar_t src = bound::get(src_ptr_NC, osxyz, sxyz);
+              *out_ptr_NCXYZ += src * (gxx * wyy * wzz);
+              out_ptr_NCXYZ[out_sK] += src * (wxx * gyy * wzz);
+              out_ptr_NCXYZ[2 * out_sK] += src * (wxx * wyy * gzz);
+            }
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          else if (do_push) {
+            if (trgt_K == 1) {
+              // Diff w.r.t. push/pull
+              scalar_t* out_ptr_NC = out_ptr_NC0;
+              for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+                bound::add(out_ptr_NC, ooxyz, (wxx * wyy * wzz) * target[c], sxyz);
+            } else {
+              // Diff w.r.t. sgrad
+              scalar_t* out_ptr_NC = out_ptr_NC0;
+              for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC) {
+                scalar_t val = (gxx * wyy * wzz) * target[c] + (wxx * gyy * wzz) * target[c + C] +
+                    (wxx * wyy * gzz) * target[c + C * 2];
+                bound::add(out_ptr_NC, ooxyz, val, sxyz);
+              }
+            }
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Count ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          else if (do_count) {
+            bound::add(out_ptr_NC0, ooxyz, (wxx * wyy * wzz), sxyz);
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          if (do_grad) {
+            if (trgt_K == 1) {
+              // Diff w.r.t. pull/push
+              scalar_t* src_ptr_NC = src_ptr_NC0;
+              scalar_t dot = static_cast<scalar_t>(0);
+              for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+                scalar_t src = bound::get(src_ptr_NC, osxyz, sxyz);
+                dot += (trgt_ptr ? src * target[c] : src);
+                // trgt_ptr == 0 in the backward pass of 'count'
+              }
+              ogx += (gxx * wyy * wzz) * dot;
+              ogy += (wxx * gyy * wzz) * dot;
+              ogz += (wxx * wyy * gzz) * dot;
+            } else {
+              // Diff w.r.t. sgrad
+              scalar_t* src_ptr_NC = src_ptr_NC0;
+              scalar_t dot0, dot1, dot2;
+              dot0 = dot1 = dot2 = static_cast<scalar_t>(0);
+              for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+                scalar_t src = bound::get(src_ptr_NC, osxyz, sxyz);
+                dot0 += src * target[c];
+                dot1 += src * target[c + C];
+                dot2 += src * target[c + C * 2];
+              }
+              ogx += (hxx * wyy * wzz) * dot0 + (gxx * gyy * wzz) * dot1 + (gxx * wyy * gzz) * dot2;
+              ogy += (gxx * gyy * wzz) * dot0 + (wxx * hyy * wzz) * dot1 + (wxx * gyy * gzz) * dot2;
+              ogz += (gxx * wyy * gzz) * dot0 + (wxx * gyy * gzz) * dot1 + (wxx * wyy * hzz) * dot2;
+            }
+          }
+
+        } // x
+      } // y
+    } // z
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY + d * grad_sZ;
+      (*grad_ptr_NXYZ) = ogx;
+      grad_ptr_NXYZ[grad_sC] = ogy;
+      grad_ptr_NXYZ[grad_sC * 2] = ogz;
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     GENERIC INTERPOLATION 2D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate2d(
+      scalar_t x,
+      scalar_t y,
+      offset_t w,
+      offset_t h,
+      offset_t n) const {
+    // Get corner pixel values from (x, y)
+    offset_t bx0, bx1, by0, by1;
+    interpolation::bounds(interpolation0, x, bx0, bx1);
+    interpolation::bounds(interpolation1, y, by0, by1);
+    offset_t dbx = bx1 - bx0;
+    offset_t dby = by1 - by0;
+
+    // Pre-compute offsets and target value
+    scalar_t* src_ptr_NC0 = src_ptr + n * src_sN;
+    scalar_t* out_ptr_NC0 = out_ptr + n * out_sN;
+    scalar_t* out_ptr_NCXY0 = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+    scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+    scalar_t target[2 * MONAI_MAX_NUM_CHANNELS];
+    if (trgt_ptr && (do_push || do_grad))
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC) {
+        target[c] = *trgt_ptr_NCXY;
+        if (trgt_K > 1) {
+          target[c + C] = trgt_ptr_NCXY[trgt_sK];
+        }
+      }
+
+    // Initialize output
+    scalar_t* out_ptr_NCXY = out_ptr_NCXY0;
+    if (do_pull || do_sgrad) {
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC) {
+        *out_ptr_NCXY = static_cast<scalar_t>(0);
+        if (do_sgrad) {
+          out_ptr_NCXY[out_sK] = static_cast<scalar_t>(0);
+        }
+      }
+    }
+
+    // Pre-compute indices/weights/grad
+    scalar_t wx[8], wy[8]; // B-spline weights
+    scalar_t gx[8], gy[8]; // B-spline derivatives
+    scalar_t hx[8], hy[8]; // B-spline 2nd derivatives
+    offset_t ix[8], iy[8]; // Warped indices
+    uint8_t sx[8], sy[8]; // Warped indices
+
+    {
+      scalar_t *owy = static_cast<scalar_t*>(wy), *ogy = static_cast<scalar_t*>(gy), *ohy = static_cast<scalar_t*>(hy);
+      offset_t* oiy = static_cast<offset_t*>(iy);
+      uint8_t* osy = static_cast<uint8_t*>(sy);
+      for (offset_t by = by0; by <= by1; ++by) {
+        scalar_t dy = y - by;
+        *(owy++) = interpolation::fastweight(interpolation1, dy);
+        if (do_grad || do_sgrad)
+          *(ogy++) = interpolation::fastgrad(interpolation1, dy);
+        if (do_grad && trgt_sK > 1)
+          *(ohy++) = interpolation::fasthess(interpolation1, dy);
+        *(osy++) = bound::sign(bound1, by, src_Y);
+        *(oiy++) = bound::index(bound1, by, src_Y);
+      }
+    }
+    {
+      scalar_t *owx = static_cast<scalar_t*>(wx), *ogx = static_cast<scalar_t*>(gx), *ohx = static_cast<scalar_t*>(hx);
+      offset_t* oix = static_cast<offset_t*>(ix);
+      uint8_t* osx = static_cast<uint8_t*>(sx);
+      for (offset_t bx = bx0; bx <= bx1; ++bx) {
+        scalar_t dx = x - bx;
+        *(owx++) = interpolation::fastweight(interpolation0, dx);
+        if (do_grad || do_sgrad)
+          *(ogx++) = interpolation::fastgrad(interpolation0, dx);
+        if (do_grad && trgt_sK > 1)
+          *(ohx++) = interpolation::fasthess(interpolation0, dx);
+        *(osx++) = bound::sign(bound0, bx, src_X);
+        *(oix++) = bound::index(bound0, bx, src_X);
+      }
+    }
+
+    // Convolve coefficients with basis functions
+    scalar_t ogx, ogy;
+    ogx = ogy = static_cast<scalar_t>(0);
+    for (offset_t j = 0; j <= dby; ++j) {
+      offset_t ooy = iy[j] * out_sY;
+      offset_t osy = iy[j] * src_sY;
+      uint8_t syy = sy[j];
+      scalar_t wyy = wy[j];
+      scalar_t gyy = gy[j];
+      scalar_t hyy = hy[j];
+      for (offset_t i = 0; i <= dbx; ++i) {
+        offset_t ooxy = ooy + ix[i] * out_sX;
+        offset_t osxy = osy + ix[i] * src_sX;
+        uint8_t sxy = syy * sx[i];
+        scalar_t wxx = wx[i];
+        scalar_t gxx = gx[i];
+        scalar_t hxx = hx[i];
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        if (do_pull) {
+          scalar_t* src_ptr_NC = src_ptr_NC0;
+          scalar_t* out_ptr_NCXY = out_ptr_NCXY0;
+          for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC)
+            *out_ptr_NCXY += bound::get(src_ptr_NC, osxy, sxy) * (wxx * wyy);
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        else if (do_sgrad) {
+          scalar_t* src_ptr_NC = src_ptr_NC0;
+          scalar_t* out_ptr_NCXY = out_ptr_NCXY0;
+          for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
+            scalar_t src = bound::get(src_ptr_NC, osxy, sxy);
+            *out_ptr_NCXY += src * (gxx * wyy);
+            out_ptr_NCXY[out_sK] += src * (wxx * gyy);
+          }
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        else if (do_push) {
+          if (trgt_K == 1) {
+            // Diff w.r.t. push/pull
+            scalar_t* out_ptr_NC = out_ptr_NC0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+              bound::add(out_ptr_NC, ooxy, (wxx * wyy) * target[c], sxy);
+          } else {
+            // Diff w.r.t. sgrad
+            scalar_t* out_ptr_NC = out_ptr_NC0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC) {
+              scalar_t val = (gxx * wyy) * target[c] + (wxx * gyy) * target[c + C];
+              bound::add(out_ptr_NC, ooxy, val, sxy);
+            }
+          }
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Count ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        else if (do_count) {
+          bound::add(out_ptr_NC0, ooxy, (wxx * wyy), sxy);
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        if (do_grad) {
+          if (trgt_K == 1) {
+            // Diff w.r.t. pull/push
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t dot = static_cast<scalar_t>(0);
+            for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+              scalar_t src = bound::get(src_ptr_NC, osxy, sxy);
+              dot += (trgt_ptr ? src * target[c] : src);
+              // trgt_ptr == 0 in the backward pass of 'count'
+            }
+            ogx += (gxx * wyy) * dot;
+            ogy += (wxx * gyy) * dot;
+          } else {
+            // Diff w.r.t. sgrad
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t dot0, dot1;
+            dot0 = dot1 = static_cast<scalar_t>(0);
+            for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+              scalar_t src = bound::get(src_ptr_NC, osxy, sxy);
+              dot0 += src * target[c];
+              dot1 += src * target[c + C];
+            }
+            ogx += (hxx * wyy) * dot0 + (gxx * gyy) * dot1;
+            ogy += (gxx * gyy) * dot0 + (wxx * hyy) * dot1;
+          }
+        }
+
+      } // x
+    } // y
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      scalar_t* grad_ptr_NXY = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY;
+      (*grad_ptr_NXY) = ogx;
+      grad_ptr_NXY[grad_sC] = ogy;
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     LINEAR INTERPOLATION 3D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate3d_trilinear(
+      scalar_t x,
+      scalar_t y,
+      scalar_t z,
+      offset_t w,
+      offset_t h,
+      offset_t d,
+      offset_t n) const {
+    // Get corner pixel values from (x, y, z)
+    offset_t ix0 = static_cast<offset_t>(std::floor(x));
+    offset_t iy0 = static_cast<offset_t>(std::floor(y));
+    offset_t iz0 = static_cast<offset_t>(std::floor(z));
+
+    // Interpolation weights (inversely proportional to distance)
+    scalar_t dx1 = x - ix0;
+    scalar_t dy1 = y - iy0;
+    scalar_t dz1 = z - iz0;
+    scalar_t dx0 = 1. - dx1;
+    scalar_t dy0 = 1. - dy1;
+    scalar_t dz0 = 1. - dz1;
+    scalar_t w000 = dx0 * dy0 * dz0;
+    scalar_t w100 = dx1 * dy0 * dz0;
+    scalar_t w010 = dx0 * dy1 * dz0;
+    scalar_t w001 = dx0 * dy0 * dz1;
+    scalar_t w110 = dx1 * dy1 * dz0;
+    scalar_t w011 = dx0 * dy1 * dz1;
+    scalar_t w101 = dx1 * dy0 * dz1;
+    scalar_t w111 = dx1 * dy1 * dz1;
+
+    // Sign (/!\ compute sign before warping indices)
+    int8_t sx1 = bound::sign(bound0, ix0 + 1, src_X);
+    int8_t sy1 = bound::sign(bound1, iy0 + 1, src_Y);
+    int8_t sz1 = bound::sign(bound2, iz0 + 1, src_Z);
+    int8_t sx0 = bound::sign(bound0, ix0, src_X);
+    int8_t sy0 = bound::sign(bound1, iy0, src_Y);
+    int8_t sz0 = bound::sign(bound2, iz0, src_Z);
+    int8_t s000 = sx0 * sy0 * sz0;
+    int8_t s100 = sx1 * sy0 * sz0;
+    int8_t s010 = sx0 * sy1 * sz0;
+    int8_t s001 = sx0 * sy0 * sz1;
+    int8_t s110 = sx1 * sy1 * sz0;
+    int8_t s011 = sx0 * sy1 * sz1;
+    int8_t s101 = sx1 * sy0 * sz1;
+    int8_t s111 = sx1 * sy1 * sz1;
+
+    // Warp indices
+    offset_t ix1, iy1, iz1;
+    ix1 = bound::index(bound0, ix0 + 1, src_X);
+    iy1 = bound::index(bound1, iy0 + 1, src_Y);
+    iz1 = bound::index(bound2, iz0 + 1, src_Z);
+    ix0 = bound::index(bound0, ix0, src_X);
+    iy0 = bound::index(bound1, iy0, src_Y);
+    iz0 = bound::index(bound2, iz0, src_Z);
+
+    // Offsets into source volume
+    offset_t o000, o100, o010, o001, o110, o011, o101, o111;
+
+    if (do_pull || do_grad || do_sgrad) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      scalar_t gx = static_cast<scalar_t>(0);
+      scalar_t gy = static_cast<scalar_t>(0);
+      scalar_t gz = static_cast<scalar_t>(0);
+      scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      if (trgt_K == 1) {
+        // backward w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt = trgt_ptr ? *trgt_ptr_NCXYZ : static_cast<scalar_t>(1);
+          // ^ trgt_ptr == 0 during the backward pass of count
+          src = bound::get(src_ptr_NC, o000, s000);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy0 * dz0 * src;
+          gy -= dx0 * dz0 * src;
+          gz -= dx0 * dy0 * src;
+          src = bound::get(src_ptr_NC, o100, s100);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy0 * dz0 * src;
+          gy -= dx1 * dz0 * src;
+          gz -= dx1 * dy0 * src;
+          src = bound::get(src_ptr_NC, o010, s010);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy1 * dz0 * src;
+          gy += dx0 * dz0 * src;
+          gz -= dx0 * dy1 * src;
+          src = bound::get(src_ptr_NC, o110, s110);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy1 * dz0 * src;
+          gy += dx1 * dz0 * src;
+          gz -= dx1 * dy1 * src;
+          src = bound::get(src_ptr_NC, o001, s001);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy0 * dz1 * src;
+          gy -= dx0 * dz1 * src;
+          gz += dx0 * dy0 * src;
+          src = bound::get(src_ptr_NC, o101, s101);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy0 * dz1 * src;
+          gy -= dx1 * dz1 * src;
+          gz += dx1 * dy0 * src;
+          src = bound::get(src_ptr_NC, o011, s011);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy1 * dz1 * src;
+          gy += dx0 * dz1 * src;
+          gz += dx0 * dy1 * src;
+          src = bound::get(src_ptr_NC, o111, s111);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy1 * dz1 * src;
+          gy += dx1 * dz1 * src;
+          gz += dx1 * dy1 * src;
+        }
+      } else {
+        // backward w.r.t. sgrad
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt0 = *trgt_ptr_NCXYZ, trgt1 = trgt_ptr_NCXYZ[trgt_sK], trgt2 = trgt_ptr_NCXYZ[trgt_sK * 2];
+          src = bound::get(src_ptr_NC, o000, s000);
+          gx += (dz0 * trgt1 + dy0 * trgt2) * src;
+          gy += (dz0 * trgt0 + dx0 * trgt2) * src;
+          gz += (dy0 * trgt0 + dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o100, s100);
+          gx += (-dz0 * trgt1 - dy0 * trgt2) * src;
+          gy += (-dz0 * trgt0 + dx1 * trgt2) * src;
+          gz += (-dy0 * trgt0 + dx1 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o010, s010);
+          gx += (-dz0 * trgt1 + dy1 * trgt2) * src;
+          gy += (-dz0 * trgt0 - dx0 * trgt2) * src;
+          gz += (dy1 * trgt0 - dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o110, s110);
+          gx += (dz0 * trgt1 - dy1 * trgt2) * src;
+          gy += (dz0 * trgt0 - dx1 * trgt2) * src;
+          gz += (-dy1 * trgt0 - dx1 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o001, s001);
+          gx += (dz1 * trgt1 - dy0 * trgt2) * src;
+          gy += (dz1 * trgt0 - dx0 * trgt2) * src;
+          gz += (-dy0 * trgt0 - dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o101, s101);
+          gx += (-dz1 * trgt1 + dy0 * trgt2) * src;
+          gy += (-dz1 * trgt0 - dx1 * trgt2) * src;
+          gz += (dy0 * trgt0 - dx1 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o011, s011);
+          gx += (-dz1 * trgt1 - dy1 * trgt2) * src;
+          gy += (-dz1 * trgt0 + dx0 * trgt2) * src;
+          gz += (-dy1 * trgt0 + dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o111, s111);
+          gx += (dz1 * trgt1 + dy1 * trgt2) * src;
+          gy += (dz1 * trgt0 + dx1 * trgt2) * src;
+          gz += (dy1 * trgt0 + dx1 * trgt1) * src;
+        }
+      }
+
+      scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY + d * grad_sZ;
+      (*grad_ptr_NXYZ) = gx;
+      grad_ptr_NXYZ[grad_sC] = gy;
+      grad_ptr_NXYZ[grad_sC * 2] = gz;
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_pull) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
+        *out_ptr_NCXYZ = bound::get(src_ptr_NC, o000, s000) * w000 + bound::get(src_ptr_NC, o100, s100) * w100 +
+            bound::get(src_ptr_NC, o010, s010) * w010 + bound::get(src_ptr_NC, o110, s110) * w110 +
+            bound::get(src_ptr_NC, o001, s001) * w001 + bound::get(src_ptr_NC, o101, s101) * w101 +
+            bound::get(src_ptr_NC, o011, s011) * w011 + bound::get(src_ptr_NC, o111, s111) * w111;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
+    else if (do_sgrad) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
+        scalar_t src000 = bound::get(src_ptr_NC, o000, s000);
+        scalar_t src100 = bound::get(src_ptr_NC, o100, s100);
+        scalar_t src010 = bound::get(src_ptr_NC, o010, s010);
+        scalar_t src110 = bound::get(src_ptr_NC, o110, s110);
+        scalar_t src001 = bound::get(src_ptr_NC, o001, s001);
+        scalar_t src101 = bound::get(src_ptr_NC, o101, s101);
+        scalar_t src011 = bound::get(src_ptr_NC, o011, s011);
+        scalar_t src111 = bound::get(src_ptr_NC, o111, s111);
+        *out_ptr_NCXYZ = -dy0 * dz0 * src000 + dy0 * dz0 * src100 - dy1 * dz0 * src010 + dy1 * dz0 * src110 -
+            dy0 * dz1 * src001 + dy0 * dz1 * src101 - dy1 * dz1 * src011 + dy1 * dz1 * src111;
+        out_ptr_NCXYZ[out_sK] = -dx0 * dz0 * src000 - dx1 * dz0 * src100 + dx0 * dz0 * src010 + dx1 * dz0 * src110 -
+            dx0 * dz1 * src001 - dx1 * dz1 * src101 + dx0 * dz1 * src011 + dx1 * dz1 * src111;
+        out_ptr_NCXYZ[out_sK * 2] = -dx0 * dy0 * src000 - dx1 * dy0 * src100 - dx0 * dy1 * src010 - dx1 * dy1 * src110 +
+            dx0 * dy0 * src001 + dx1 * dy0 * src101 + dx0 * dy1 * src011 + dx1 * dy1 * src111;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_push) {
+      // Offsets into 'push' volume
+      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      if (trgt_K == 1) {
+        // Diff w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt = *trgt_ptr_NCXYZ;
+          bound::add(out_ptr_NC, o000, w000 * trgt, s000);
+          bound::add(out_ptr_NC, o100, w100 * trgt, s100);
+          bound::add(out_ptr_NC, o010, w010 * trgt, s010);
+          bound::add(out_ptr_NC, o110, w110 * trgt, s110);
+          bound::add(out_ptr_NC, o001, w001 * trgt, s001);
+          bound::add(out_ptr_NC, o101, w101 * trgt, s101);
+          bound::add(out_ptr_NC, o011, w011 * trgt, s011);
+          bound::add(out_ptr_NC, o111, w111 * trgt, s111);
+        }
+      } else {
+        // Diff w.r.t. sgrad
+        scalar_t val;
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt0 = *trgt_ptr_NCXYZ, trgt1 = trgt_ptr_NCXYZ[trgt_sK], trgt2 = trgt_ptr_NCXYZ[trgt_sK * 2];
+          val = -dy0 * dz0 * trgt0 - dx0 * dz0 * trgt1 - dx0 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o000, val, s000);
+          val = dy0 * dz0 * trgt0 - dx1 * dz0 * trgt1 - dx1 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o100, val, s100);
+          val = -dy1 * dz0 * trgt0 + dx0 * dz0 * trgt1 - dx0 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o010, val, s010);
+          val = dy1 * dz0 * trgt0 + dx1 * dz0 * trgt1 - dx1 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o110, val, s110);
+          val = -dy0 * dz1 * trgt0 - dx0 * dz1 * trgt1 + dx0 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o001, val, s001);
+          val = dy0 * dz1 * trgt0 - dx1 * dz1 * trgt1 + dx1 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o101, val, s101);
+          val = -dy1 * dz1 * trgt0 + dx0 * dz1 * trgt1 + dx0 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o011, val, s011);
+          val = dy1 * dz1 * trgt0 + dx1 * dz1 * trgt1 + dx1 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o111, val, s111);
+        }
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_count) {
+      // Offsets into 'push' volume
+      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+
+      scalar_t* out_ptr_N = out_ptr + n * out_sN;
+      bound::add(out_ptr_N, o000, w000, s000);
+      bound::add(out_ptr_N, o100, w100, s100);
+      bound::add(out_ptr_N, o010, w010, s010);
+      bound::add(out_ptr_N, o110, w110, s110);
+      bound::add(out_ptr_N, o001, w001, s001);
+      bound::add(out_ptr_N, o101, w101, s101);
+      bound::add(out_ptr_N, o011, w011, s011);
+      bound::add(out_ptr_N, o111, w111, s111);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     LINEAR INTERPOLATION 2D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate2d_bilinear(
+      scalar_t x,
+      scalar_t y,
+      offset_t w,
+      offset_t h,
+      offset_t n) const {
+    // Get corner pixel values from (x, y, z)
+    offset_t ix0 = static_cast<offset_t>(std::floor(x));
+    offset_t iy0 = static_cast<offset_t>(std::floor(y));
+
+    // Interpolation weights (inversely proportional to distance)
+    scalar_t dx1 = x - ix0;
+    scalar_t dy1 = y - iy0;
+    scalar_t dx0 = 1. - dx1;
+    scalar_t dy0 = 1. - dy1;
+    scalar_t w00 = dx0 * dy0;
+    scalar_t w10 = dx1 * dy0;
+    scalar_t w01 = dx0 * dy1;
+    scalar_t w11 = dx1 * dy1;
+    ;
+
+    // Sign (/!\ compute sign before warping indices)
+    int8_t sx1 = bound::sign(bound0, ix0 + 1, src_X);
+    int8_t sy1 = bound::sign(bound1, iy0 + 1, src_Y);
+    int8_t sx0 = bound::sign(bound0, ix0, src_X);
+    int8_t sy0 = bound::sign(bound1, iy0, src_Y);
+    int8_t s00 = sx0 * sy0;
+    int8_t s10 = sx1 * sy0;
+    int8_t s01 = sx0 * sy1;
+    int8_t s11 = sx1 * sy1;
+
+    // Warp indices
+    offset_t ix1, iy1;
+    ix1 = bound::index(bound0, ix0 + 1, src_X);
+    iy1 = bound::index(bound1, iy0 + 1, src_Y);
+    ix0 = bound::index(bound0, ix0, src_X);
+    iy0 = bound::index(bound1, iy0, src_Y);
+
+    // Offsets into source volume
+    offset_t o00, o10, o01, o11;
+    if (do_pull || do_grad || do_sgrad) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+      scalar_t gx = static_cast<scalar_t>(0);
+      scalar_t gy = static_cast<scalar_t>(0);
+      scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      if (trgt_K == 1) {
+        // backward w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt = trgt_ptr ? *trgt_ptr_NCXY : static_cast<scalar_t>(1);
+          // ^ trgt_ptr == 0 during the backward pass of count
+          src = bound::get(src_ptr_NC, o00, s00);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy0 * src;
+          gy -= dx0 * src;
+          src = bound::get(src_ptr_NC, o10, s10);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy0 * src;
+          gy -= dx1 * src;
+          src = bound::get(src_ptr_NC, o01, s01);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy1 * src;
+          gy += dx0 * src;
+          src = bound::get(src_ptr_NC, o11, s11);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy1 * src;
+          gy += dx1 * src;
+        }
+      } else {
+        // backward w.r.t. sgrad
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt0 = *trgt_ptr_NCXY, trgt1 = trgt_ptr_NCXY[trgt_sK];
+          src = bound::get(src_ptr_NC, o00, s00);
+          gx += trgt1 * src;
+          gy += trgt0 * src;
+          src = bound::get(src_ptr_NC, o10, s10);
+          gx -= trgt1 * src;
+          gy -= trgt0 * src;
+          src = bound::get(src_ptr_NC, o01, s01);
+          gx -= trgt1 * src;
+          gy -= trgt0 * src;
+          src = bound::get(src_ptr_NC, o11, s11);
+          gx += trgt1 * src;
+          gy += trgt0 * src;
+        }
+      }
+
+      scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY;
+      (*grad_ptr_NXYZ) = gx;
+      grad_ptr_NXYZ[grad_sC] = gy;
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_pull) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+      scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
+        *out_ptr_NCXY = bound::get(src_ptr_NC, o00, s00) * w00 + bound::get(src_ptr_NC, o10, s10) * w10 +
+            bound::get(src_ptr_NC, o01, s01) * w01 + bound::get(src_ptr_NC, o11, s11) * w11;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_sgrad) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+      scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
+        scalar_t src00 = bound::get(src_ptr_NC, o00, s00);
+        scalar_t src10 = bound::get(src_ptr_NC, o10, s10);
+        scalar_t src01 = bound::get(src_ptr_NC, o01, s01);
+        scalar_t src11 = bound::get(src_ptr_NC, o11, s11);
+        *out_ptr_NCXY = -dy0 * src00 + dy0 * src10 - dy1 * src01 + dy1 * src11;
+        out_ptr_NCXY[out_sK] = -dx0 * src00 - dx1 * src10 + dx0 * src01 + dx1 * src11;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_push) {
+      // Offsets into 'push' volume
+      o00 = ix0 * out_sX + iy0 * out_sY;
+      o10 = ix1 * out_sX + iy0 * out_sY;
+      o01 = ix0 * out_sX + iy1 * out_sY;
+      o11 = ix1 * out_sX + iy1 * out_sY;
+      scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      if (trgt_K == 1) {
+        // Diff w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt = *trgt_ptr_NCXY;
+          bound::add(out_ptr_NC, o00, w00 * trgt, s00);
+          bound::add(out_ptr_NC, o10, w10 * trgt, s10);
+          bound::add(out_ptr_NC, o01, w01 * trgt, s01);
+          bound::add(out_ptr_NC, o11, w11 * trgt, s11);
+        }
+      } else {
+        // Diff w.r.t. sgrad
+        scalar_t val;
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt0 = *trgt_ptr_NCXY, trgt1 = trgt_ptr_NCXY[trgt_sK];
+          val = -dy0 * trgt0 - dx0 * trgt1;
+          bound::add(out_ptr_NC, o00, val, s00);
+          val = dy0 * trgt0 - dx1 * trgt1;
+          bound::add(out_ptr_NC, o10, val, s10);
+          val = -dy1 * trgt0 + dx0 * trgt1;
+          bound::add(out_ptr_NC, o01, val, s01);
+          val = dy1 * trgt0 + dx1 * trgt1;
+          bound::add(out_ptr_NC, o11, val, s11);
+        }
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_count) {
+      // Offsets into 'push' volume
+      o00 = ix0 * out_sX + iy0 * out_sY;
+      o10 = ix1 * out_sX + iy0 * out_sY;
+      o01 = ix0 * out_sX + iy1 * out_sY;
+      o11 = ix1 * out_sX + iy1 * out_sY;
+
+      scalar_t* out_ptr_N = out_ptr + n * out_sN;
+      bound::add(out_ptr_N, o00, w00, s00);
+      bound::add(out_ptr_N, o10, w10, s10);
+      bound::add(out_ptr_N, o01, w01, s01);
+      bound::add(out_ptr_N, o11, w11, s11);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                  NEAREST NEIGHBOR INTERPOLATION 3D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate3d_nearest(
+      scalar_t x,
+      scalar_t y,
+      scalar_t z,
+      offset_t w,
+      offset_t h,
+      offset_t d,
+      offset_t n) const {
+    offset_t ix = static_cast<offset_t>(std::round(x));
+    offset_t iy = static_cast<offset_t>(std::round(y));
+    offset_t iz = static_cast<offset_t>(std::round(z));
+
+    // Boundary condition (/!\ compute sign before warping indices)
+    int8_t sx = bound::sign(bound0, ix, src_X);
+    int8_t sy = bound::sign(bound1, iy, src_Y);
+    int8_t sz = bound::sign(bound2, iz, src_Z);
+    ix = bound::index(bound0, ix, src_X);
+    iy = bound::index(bound1, iy, src_Y);
+    iz = bound::index(bound2, iz, src_Z);
+
+    // Sign
+    int8_t s = sz * sy * sx;
+
+    if (do_pull) {
+      offset_t o = iz * src_sZ + iy * src_sY + ix * src_sX;
+      scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC)
+        *out_ptr_NCXYZ = bound::get(src_ptr_NC, o, s);
+    } else if (do_push && trgt_K == 1) {
+      offset_t o = iz * out_sZ + iy * out_sY + ix * out_sX;
+      scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, *trgt_ptr_NCXYZ, s);
+    } else if (do_count) {
+      offset_t o = iz * out_sZ + iy * out_sY + ix * out_sX;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, static_cast<scalar_t>(1), s);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                  NEAREST NEIGHBOR INTERPOLATION 2D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate2d_nearest(
+      scalar_t x,
+      scalar_t y,
+      offset_t w,
+      offset_t h,
+      offset_t n) const {
+    offset_t ix = static_cast<offset_t>(std::round(x));
+    offset_t iy = static_cast<offset_t>(std::round(y));
+
+    // Boundary condition (/!\ compute sign before warping indices)
+    int8_t sx = bound::sign(bound0, ix, src_X);
+    int8_t sy = bound::sign(bound1, iy, src_Y);
+    ix = bound::index(bound0, ix, src_X);
+    iy = bound::index(bound1, iy, src_Y);
+
+    // Sign
+    int8_t s = sy * sx;
+
+    if (do_pull) {
+      offset_t o = iy * src_sY + ix * src_sX;
+      scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC)
+        *out_ptr_NCXY = bound::get(src_ptr_NC, o, s);
+    } else if (do_push && trgt_K == 1) {
+      offset_t o = iy * out_sY + ix * out_sX;
+      scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, *trgt_ptr_NCXY, s);
+    } else if (do_count) {
+      offset_t o = iy * out_sY + ix * out_sX;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, static_cast<scalar_t>(1), s);
+    }
+  }
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //            LINEAR INTERPOLATION 3D + SLIDING BOUNDARY
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // TODO
+  } // namespace
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                    FUNCTIONAL FORM WITH DISPATCH
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#define PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, SourceType0) \
+  template std::deque<Tensor> pushpull(                                    \
+      const SourceType0&,                                                  \
+      const Tensor&,                                                       \
+      const Tensor&,                                                       \
+      BoundType0,                                                          \
+      InterpolationType0,                                                  \
+      bool,                                                                \
+      bool,                                                                \
+      bool,                                                                \
+      bool,                                                                \
+      bool,                                                                \
+      bool);                                                               \
+  template std::deque<Tensor> pushpull(                                    \
+      const SourceType0&, const Tensor&, BoundType0, InterpolationType0, bool, bool, bool, bool, bool, bool)
+#define PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType0)         \
+  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, IntArrayRef); \
+  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, Tensor)
+#define PUSHPULL_INSTANTIATE1(BoundType0)               \
+  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType); \
+  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationVectorRef)
+#define PUSHPULL_INSTANTIATE        \
+  PUSHPULL_INSTANTIATE1(BoundType); \
+  PUSHPULL_INSTANTIATE1(BoundVectorRef)
+
+  // ~~~ CPU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  // Two arguments (source, grid)
+  // > `bound` and `interpolation` can be single arguments or vectors.
+  template <typename BoundType, typename InterpolationType, typename SourceType>
+  MONAI_HOST std::deque<Tensor> pushpull(
+      const SourceType& source,
+      const Tensor& grid,
+      BoundType bound,
+      InterpolationType interpolation,
+      bool extrapolate,
+      bool do_pull,
+      bool do_push,
+      bool do_count,
+      bool do_grad,
+      bool do_sgrad) {
+    return AT_DISPATCH_FLOATING_TYPES(grid.scalar_type(), "pushpull", [&] {
+      PushPullImpl<scalar_t, int32_t> f(
+          grid.dim() - 2, bound, interpolation, extrapolate, do_pull, do_push, do_count, do_grad, do_sgrad);
+      f.ioset(source, grid);
+      f.loop();
+      return f.output;
+    });
+  }
+
+  // Three arguments (source, grid, target)
+  // > `bound` and `interpolation` can be single arguments or vectors.
+  // > `source` can be a tensor or a vector of dimensions.
+  template <typename BoundType, typename InterpolationType, typename SourceType>
+  MONAI_HOST std::deque<Tensor> pushpull(
+      const SourceType& source,
+      const Tensor& grid,
+      const Tensor& target,
+      BoundType bound,
+      InterpolationType interpolation,
+      bool extrapolate,
+      bool do_pull,
+      bool do_push,
+      bool do_count,
+      bool do_grad,
+      bool do_sgrad) {
+    return AT_DISPATCH_FLOATING_TYPES(grid.scalar_type(), "pushpull", [&] {
+      PushPullImpl<scalar_t, int32_t> f(
+          grid.dim() - 2, bound, interpolation, extrapolate, do_pull, do_push, do_count, do_grad, do_sgrad);
+      f.ioset(source, grid, target);
+      f.loop();
+      return f.output;
+    });
+  }
+
+  PUSHPULL_INSTANTIATE;
+
+} // namespace <device>
+
+} // namespace monai

--- a/monai/csrc/resample/pushpull_cuda.cu
+++ b/monai/csrc/resample/pushpull_cuda.cu
@@ -1,0 +1,1780 @@
+/*
+Copyright 2020 MONAI Consortium
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// adapted from https://github.com/balbasty/nitorch
+
+// This file implements spline interpolation / sampling and its adjoint
+// operations. It corresponds loosely to torch's `GridSampler`.
+// It handles boundary conditions and interpolation orders defined in
+// `utils/resample_utils.h` and `utils/resample_utils.h`.
+// These parameters can be specified per dimension.
+// Isotorpic 0-th and 1-st order interpolation have their own (faster)
+// implementations. Sliding boundary conditions are also implemented
+// separately.
+
+// TODO:
+// . [DONE] generic 3d
+// . [DONE] generic 2d
+// . sliding nearest 3d
+// . sliding nearest 2d
+// . sliding linear 3d
+// . sliding linear 2d
+// . slinding generic 3d
+// . sliding generic 2d
+// . [DONE] spatial gradient mode (without mutliplication with output gradient)
+// . [DONE] second order gradients (backward pass for spatial gradients)
+// . performance tests
+// . input bound/inter are always vectors -> clean unused constructors
+
+#include <ATen/ATen.h>
+#include <tuple>
+#include "bounds_common.h"
+#include "interpolation_common.h"
+#include "utils/resample_utils.h"
+//#include <cstdio>
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// GPU-specific parameters
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/detail/KernelUtils.h>
+#include <c10/macros/Macros.h>
+using namespace at::cuda::detail;
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// maximum number of channels
+// > not used in mode isotropic nearest/linear
+#ifndef MONAI_MAX_NUM_CHANNELS
+#define MONAI_MAX_NUM_CHANNELS 1024
+#endif
+
+// This parameter allows for a little bit of tolerance when considering
+// a coordinate as "out-of-bound" (if !extrapolate)
+#define TINY 5e-2
+
+using at::Tensor;
+using at::TensorOptions;
+using c10::IntArrayRef;
+
+namespace monai {
+MONAI_NAMESPACE_DEVICE { // cuda
+
+  namespace { // anonymous namespace > everything inside has internal linkage
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                        GENERIC PUSHPULL CLASS
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // This class implements the bulk of the code.
+  // /!\ No type and shape checking is performed here.
+
+  template <typename scalar_t, typename offset_t>
+  class PushPullImpl {
+   public:
+    // ~~~ CONSTRUCTORS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundVectorRef bound,
+        InterpolationVectorRef interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound1(bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound2(
+              bound.size() > 2 ? bound[2]
+                               : bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          interpolation0(interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation1(
+              interpolation.size() > 1 ? interpolation[1]
+                                       : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation2(
+              interpolation.size() > 2
+                  ? interpolation[2]
+                  : interpolation.size() > 1 ? interpolation[1]
+                                             : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundType bound,
+        InterpolationVectorRef interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound),
+          bound1(bound),
+          bound2(bound),
+          interpolation0(interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation1(
+              interpolation.size() > 1 ? interpolation[1]
+                                       : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          interpolation2(
+              interpolation.size() > 2
+                  ? interpolation[2]
+                  : interpolation.size() > 1 ? interpolation[1]
+                                             : interpolation.size() > 0 ? interpolation[0] : InterpolationType::Linear),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundVectorRef bound,
+        InterpolationType interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound1(bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          bound2(
+              bound.size() > 2 ? bound[2]
+                               : bound.size() > 1 ? bound[1] : bound.size() > 0 ? bound[0] : BoundType::Replicate),
+          interpolation0(interpolation),
+          interpolation1(interpolation),
+          interpolation2(interpolation),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    MONAI_HOST
+    PushPullImpl(
+        int dim,
+        BoundType bound,
+        InterpolationType interpolation,
+        bool extrapolate,
+        bool do_pull,
+        bool do_push,
+        bool do_count,
+        bool do_grad,
+        bool do_sgrad)
+        : dim(dim),
+          bound0(bound),
+          bound1(bound),
+          bound2(bound),
+          interpolation0(interpolation),
+          interpolation1(interpolation),
+          interpolation2(interpolation),
+          extrapolate(extrapolate),
+          do_pull(do_pull),
+          do_push(do_push),
+          do_count(do_count),
+          do_grad(do_grad),
+          do_sgrad(do_sgrad) {
+      iso = interpolation0 == interpolation1 && interpolation0 == interpolation2;
+    }
+
+    // ~~~ PUBLIC VALUE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    std::deque<Tensor> output;
+
+    // MONAI_HOST MONAI_DEVICE void printInfo() const {
+    //   printf("dim: %d\n", dim);
+    //   printf("do_pull:  %d\n", do_pull);
+    //   printf("do_push:  %d\n", do_push);
+    //   printf("do_count: %d\n", do_count);
+    //   printf("do_sgrad: %d\n", do_sgrad);
+    //   printf("do_grad:  %d\n", do_grad);
+    //   printf("bound:         [%d %d %d]\n", static_cast<int>(bound0),
+    //     static_cast<int>(bound1), static_cast<int>(bound2));
+    //   printf("interpolation: [%d %d %d]\n", static_cast<int>(interpolation0),
+    //     static_cast<int>(interpolation1), static_cast<int>(interpolation2));
+    //   printf("src:  [%d %d %d]\n", src_Z, src_Y, src_X);
+    //   printf("trgt: [%d %d %d (%d)]\n", trgt_Z, trgt_Y, trgt_X, trgt_K);
+    //   printf("N: %d\n", N);
+    //   printf("C: %d\n", C);
+    //   printf("src  -> %lu\n", reinterpret_cast<std::uintptr_t>(src_ptr));
+    //   printf("trgt -> %lu\n", reinterpret_cast<std::uintptr_t>(trgt_ptr));
+    //   printf("grid -> %lu\n", reinterpret_cast<std::uintptr_t>(grid_ptr));
+    //   printf("out  -> %lu\n", reinterpret_cast<std::uintptr_t>(out_ptr));
+    //   printf("grad -> %lu\n", reinterpret_cast<std::uintptr_t>(grad_ptr));
+    // }
+
+    // ~~~ FUNCTORS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    MONAI_HOST void ioset // Pull
+        (const Tensor& source, const Tensor& grid) {
+      init_all();
+      init_source(source);
+      init_grid(grid);
+      init_output();
+    }
+
+    MONAI_HOST void ioset(const Tensor& source, const Tensor& grid, const Tensor& target) {
+      init_all();
+      init_source(source);
+      init_grid(grid);
+      init_target(target);
+      init_output();
+    }
+
+    MONAI_HOST void ioset // Push
+        (IntArrayRef source_size, const Tensor& grid, const Tensor& target) {
+      init_all();
+      init_source(source_size);
+      init_grid(grid);
+      init_target(target);
+      init_output();
+    }
+
+    MONAI_HOST void ioset // Count
+        (IntArrayRef source_size, const Tensor& grid) {
+      init_all();
+      init_source(source_size);
+      init_grid(grid);
+      init_output();
+    }
+
+    MONAI_DEVICE void loop(int threadIdx, int blockIdx, int blockDim, int gridDim) const;
+
+    MONAI_HOST MONAI_DEVICE int64_t voxcount() const {
+      return N * trgt_X * trgt_Y * trgt_Z;
+    }
+
+   private:
+    // ~~~ COMPONENTS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    MONAI_HOST void init_all();
+    MONAI_HOST void init_source(const Tensor& source);
+    MONAI_HOST void init_source(IntArrayRef source_size);
+    MONAI_HOST void init_grid(const Tensor& grid);
+    MONAI_HOST void init_target(const Tensor& target);
+    MONAI_HOST void init_output();
+    MONAI_DEVICE void check2d(offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void check3d(offset_t w, offset_t h, offset_t d, offset_t n) const;
+    MONAI_DEVICE void interpolate2d(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void interpolate2d_nearest(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void interpolate2d_bilinear(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const;
+    MONAI_DEVICE void interpolate2d_sliding(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n) const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate2d_sliding_nearest(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n)
+        const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate2d_sliding_bilinear(scalar_t x, scalar_t y, offset_t w, offset_t h, offset_t n)
+        const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate3d(scalar_t x, scalar_t y, scalar_t z, offset_t w, offset_t h, offset_t d, offset_t n)
+        const;
+    MONAI_DEVICE void interpolate3d_nearest(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const;
+    MONAI_DEVICE void interpolate3d_trilinear(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const;
+    MONAI_DEVICE void interpolate3d_sliding(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate3d_sliding_nearest(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const { /*TODO*/
+    }
+    MONAI_DEVICE void interpolate3d_sliding_trilinear(
+        scalar_t x,
+        scalar_t y,
+        scalar_t z,
+        offset_t w,
+        offset_t h,
+        offset_t d,
+        offset_t n) const { /*TODO*/
+    }
+
+    // ~~~ OPTIONS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    int dim; // dimensionality (2 or 3)
+    BoundType bound0; // boundary condition  // x|W
+    BoundType bound1; // boundary condition  // y|H
+    BoundType bound2; // boundary condition  // z|D
+    InterpolationType interpolation0; // interpolation order // x|W
+    InterpolationType interpolation1; // interpolation order // y|H
+    InterpolationType interpolation2; // interpolation order // z|D
+    bool iso; // isotropic interpolation?
+    bool extrapolate; // compute out-of-bound values
+    bool do_pull; // sample a volume
+    bool do_push; // splat a volume
+    bool do_count; // splatting weights (= jacobian determinant)
+    bool do_grad; // backprop: gradient of grid // pull
+    bool do_sgrad; // sample spatial gradients
+
+    // ~~~ NAVIGATORS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    TensorOptions src_opt;
+    TensorOptions grid_opt;
+    TensorOptions trgt_opt;
+    offset_t N;
+    offset_t C;
+    offset_t src_X;
+    offset_t src_Y;
+    offset_t src_Z;
+    offset_t trgt_X;
+    offset_t trgt_Y;
+    offset_t trgt_Z;
+    offset_t trgt_K;
+    offset_t src_sN;
+    offset_t src_sC;
+    offset_t src_sX;
+    offset_t src_sY;
+    offset_t src_sZ;
+    scalar_t* src_ptr;
+    offset_t trgt_sN;
+    offset_t trgt_sC;
+    offset_t trgt_sX;
+    offset_t trgt_sY;
+    offset_t trgt_sZ;
+    offset_t trgt_sK;
+    scalar_t* trgt_ptr;
+    offset_t grid_sN;
+    offset_t grid_sC;
+    offset_t grid_sX;
+    offset_t grid_sY;
+    offset_t grid_sZ;
+    scalar_t* grid_ptr;
+    offset_t out_sN;
+    offset_t out_sC;
+    offset_t out_sX;
+    offset_t out_sY;
+    offset_t out_sZ;
+    offset_t out_sK; // gradient dimension
+    scalar_t* out_ptr;
+    offset_t grad_sN;
+    offset_t grad_sC;
+    offset_t grad_sX;
+    offset_t grad_sY;
+    offset_t grad_sZ;
+    scalar_t* grad_ptr;
+  };
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                          INITIALISATION
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  void PushPullImpl<scalar_t, offset_t>::init_all() {
+    src_opt = grid_opt = trgt_opt = TensorOptions();
+    N = C = static_cast<offset_t>(1);
+    src_X = src_Y = src_Z = static_cast<offset_t>(1);
+    trgt_X = trgt_Y = trgt_Z = trgt_K = static_cast<offset_t>(1);
+    src_sN = src_sC = src_sX = src_sY = src_sZ = static_cast<offset_t>(0);
+    grid_sN = grid_sC = grid_sX = grid_sY = grid_sZ = static_cast<offset_t>(0);
+    grad_sN = grad_sC = grad_sX = grad_sY = grad_sZ = static_cast<offset_t>(0);
+    trgt_sN = trgt_sC = trgt_sX = trgt_sY = trgt_sZ = trgt_sK = static_cast<offset_t>(0);
+    out_sN = out_sC = out_sX = out_sY = out_sZ = out_sK = static_cast<offset_t>(0);
+    src_ptr = trgt_ptr = grid_ptr = out_ptr = grad_ptr = static_cast<scalar_t*>(0);
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_source(const Tensor& source) {
+    N = source.size(0);
+    C = source.size(1);
+    src_X = source.size(2);
+    src_Y = source.size(3);
+    src_Z = dim == 2 ? static_cast<offset_t>(1) : source.size(4);
+    src_sN = source.stride(0);
+    src_sC = source.stride(1);
+    src_sX = source.stride(2);
+    src_sY = source.stride(3);
+    src_sZ = dim == 2 ? static_cast<offset_t>(0) : source.stride(4);
+    src_ptr = source.data_ptr<scalar_t>();
+    src_opt = source.options();
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_source(IntArrayRef source_size) {
+    src_X = source_size[0];
+    src_Y = source_size[1];
+    src_Z = dim == 2 ? static_cast<offset_t>(1) : source_size[2];
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_grid(const Tensor& grid) {
+    N = grid.size(0);
+    trgt_X = grid.size(1);
+    trgt_Y = grid.size(2);
+    trgt_Z = dim == 2 ? static_cast<offset_t>(1) : grid.size(3);
+    grid_sN = grid.stride(0);
+    grid_sX = grid.stride(1);
+    grid_sY = grid.stride(2);
+    grid_sZ = dim == 2 ? static_cast<offset_t>(0) : grid.stride(3);
+    grid_sC = grid.stride(dim == 2 ? 3 : 4);
+    grid_ptr = grid.data_ptr<scalar_t>();
+    grid_opt = grid.options();
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_target(const Tensor& target) {
+    N = target.size(0);
+    C = target.size(1);
+    trgt_X = target.size(2);
+    trgt_Y = target.size(3);
+    trgt_Z = dim == 2 ? static_cast<offset_t>(1) : target.size(4);
+    trgt_K = target.dim() == dim + 3 ? target.size(dim == 2 ? 4 : 5) : static_cast<offset_t>(1);
+    trgt_sN = target.stride(0);
+    trgt_sC = target.stride(1);
+    trgt_sX = target.stride(2);
+    trgt_sY = target.stride(3);
+    trgt_sZ = dim == 2 ? static_cast<offset_t>(0) : target.stride(4);
+    trgt_sK = target.dim() == dim + 3 ? target.stride(dim == 2 ? 4 : 5) : static_cast<offset_t>(0);
+    trgt_ptr = target.data_ptr<scalar_t>();
+    trgt_opt = target.options();
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_HOST void PushPullImpl<scalar_t, offset_t>::init_output() {
+    output.clear();
+    if (do_pull) {
+      if (dim == 2)
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y}, src_opt));
+      else
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y, trgt_Z}, src_opt));
+      auto pull = output.back();
+      out_sN = pull.stride(0);
+      out_sC = pull.stride(1);
+      out_sX = pull.stride(2);
+      out_sY = pull.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : pull.stride(4);
+      out_sK = static_cast<offset_t>(0);
+      out_ptr = pull.template data_ptr<scalar_t>();
+    } else if (do_sgrad) {
+      if (dim == 2)
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y, 2}, src_opt));
+      else
+        output.push_back(at::empty({N, C, trgt_X, trgt_Y, trgt_Z, 3}, src_opt));
+      auto sgrad = output.back();
+      out_sN = sgrad.stride(0);
+      out_sC = sgrad.stride(1);
+      out_sX = sgrad.stride(2);
+      out_sY = sgrad.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : sgrad.stride(4);
+      out_sK = sgrad.stride(dim == 2 ? 4 : 5);
+      out_ptr = sgrad.template data_ptr<scalar_t>();
+
+      if (iso && interpolation0 == InterpolationType::Nearest)
+        sgrad.zero_();
+    } else if (do_push) {
+      if (dim == 2)
+        output.push_back(at::zeros({N, C, src_X, src_Y}, trgt_opt));
+      else
+        output.push_back(at::zeros({N, C, src_X, src_Y, src_Z}, trgt_opt));
+      auto push = output.back();
+      out_sN = push.stride(0);
+      out_sC = push.stride(1);
+      out_sX = push.stride(2);
+      out_sY = push.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : push.stride(4);
+      out_sK = static_cast<offset_t>(0);
+      out_ptr = push.template data_ptr<scalar_t>();
+    } else if (do_count) {
+      if (dim == 2)
+        output.push_back(at::zeros({N, 1, src_X, src_Y}, grid_opt));
+      else
+        output.push_back(at::zeros({N, 1, src_X, src_Y, src_Z}, grid_opt));
+      auto count = output.back();
+      out_sN = count.stride(0);
+      out_sC = count.stride(1);
+      out_sX = count.stride(2);
+      out_sY = count.stride(3);
+      out_sZ = dim == 2 ? static_cast<offset_t>(0) : count.stride(4);
+      out_sK = static_cast<offset_t>(0);
+      out_ptr = count.template data_ptr<scalar_t>();
+    }
+    if (do_grad) {
+      if (dim == 2)
+        output.push_back(at::zeros({N, src_X, src_Y, 2}, grid_opt));
+      else
+        output.push_back(at::zeros({N, src_X, src_Y, src_Z, 3}, grid_opt));
+      auto grad = output.back();
+      grad_sN = grad.stride(0);
+      grad_sX = grad.stride(1);
+      grad_sY = grad.stride(2);
+      grad_sZ = dim == 2 ? static_cast<offset_t>(0) : grad.stride(3);
+      grad_sC = grad.stride(dim == 2 ? 3 : 4);
+      grad_ptr = grad.template data_ptr<scalar_t>();
+
+      if (iso && interpolation0 == InterpolationType::Nearest)
+        grad.zero_();
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                             LOOP
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::loop(int threadIdx, int blockIdx, int blockDim, int gridDim)
+      const {
+    int64_t index = blockIdx * blockDim + threadIdx;
+    int64_t nthreads = voxcount();
+    offset_t trgt_XYZ = trgt_Z * trgt_Y * trgt_X;
+    offset_t trgt_YZ = trgt_Z * trgt_Y;
+    offset_t n, w, h, d;
+    for (offset_t i = index; index < nthreads; index += blockDim * gridDim, i = index) {
+      // Convert index: linear to sub
+      n = (i / trgt_XYZ);
+      w = (i / trgt_YZ) % trgt_X;
+      h = (i / trgt_Z) % trgt_Y;
+      d = i % trgt_Z;
+
+      if (dim == 2)
+        check2d(w, h, n);
+      else
+        check3d(w, h, d, n);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                        CHECK OUT-OF-BOUND
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  // Here, we:
+  // 1) read the [x,y,z] source coordinate for the current target voxel
+  // 3) check if the source coordinate is in bounds
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::check2d(offset_t w, offset_t h, offset_t n) const {
+    // get the corresponding input x, y, z co-ordinates from grid
+    scalar_t* grid_ptr_NXY = grid_ptr + n * grid_sN + w * grid_sX + h * grid_sY;
+    scalar_t x = *grid_ptr_NXY;
+    scalar_t y = grid_ptr_NXY[grid_sC];
+
+    // Check if out-of-bound
+    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY)))) {
+      if (do_pull || do_sgrad) {
+        scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sZ + h * out_sY;
+        for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC) {
+          *out_ptr_NCXY = static_cast<scalar_t>(0);
+          if (do_sgrad)
+            out_ptr_NCXY[out_sK] = static_cast<scalar_t>(0);
+        }
+      }
+      if (do_grad) {
+        scalar_t* grad_ptr_NXY = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY;
+        (*grad_ptr_NXY) = static_cast<scalar_t>(0);
+        grad_ptr_NXY[grad_sC] = static_cast<scalar_t>(0);
+      }
+      return;
+    }
+
+    // Next step
+    if (bound0 == BoundType::Sliding) {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate2d_sliding_nearest(x, y, w, h, n);
+          case 1:
+            return interpolate2d_sliding_bilinear(x, y, w, h, n);
+        }
+      return interpolate2d_sliding(x, y, w, h, n);
+    } else {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate2d_nearest(x, y, w, h, n);
+          case 1:
+            return interpolate2d_bilinear(x, y, w, h, n);
+        }
+      return interpolate2d(x, y, w, h, n);
+    }
+  }
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::check3d(offset_t w, offset_t h, offset_t d, offset_t n) const {
+    // get the corresponding input x, y, z co-ordinates from grid
+    scalar_t* grid_ptr_NXYZ = grid_ptr + n * grid_sN + w * grid_sX + h * grid_sY + d * grid_sZ;
+    scalar_t x = *grid_ptr_NXYZ;
+    scalar_t y = grid_ptr_NXYZ[grid_sC];
+    scalar_t z = grid_ptr_NXYZ[grid_sC * 2];
+
+    // Check if out-of-bound
+    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY)) || inbounds(z, src_Z, static_cast<scalar_t>(TINY)))) {
+      if (do_pull || do_sgrad) {
+        scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+        for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC) {
+          *out_ptr_NCXYZ = static_cast<scalar_t>(0);
+          if (do_sgrad) {
+            out_ptr_NCXYZ[out_sK] = static_cast<scalar_t>(0);
+            out_ptr_NCXYZ[out_sK * 2] = static_cast<scalar_t>(0);
+          }
+        }
+      }
+      if (do_grad) {
+        scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY + d * grad_sZ;
+        (*grad_ptr_NXYZ) = static_cast<scalar_t>(0);
+        grad_ptr_NXYZ[grad_sC] = static_cast<scalar_t>(0);
+        grad_ptr_NXYZ[grad_sC * 2] = static_cast<scalar_t>(0);
+      }
+      return;
+    }
+
+    // Next step
+    if (bound0 == BoundType::Sliding) {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate3d_sliding_nearest(x, y, z, w, h, d, n);
+          case 1:
+            return interpolate3d_sliding_trilinear(x, y, z, w, h, d, n);
+        }
+      return interpolate3d_sliding(x, y, z, w, h, d, n);
+    } else {
+      if (iso)
+        switch (static_cast<int>(interpolation0)) {
+          case 0:
+            return interpolate3d_nearest(x, y, z, w, h, d, n);
+          case 1:
+            return interpolate3d_trilinear(x, y, z, w, h, d, n);
+        }
+      return interpolate3d(x, y, z, w, h, d, n);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     GENERIC INTERPOLATION 3D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate3d(
+      scalar_t x,
+      scalar_t y,
+      scalar_t z,
+      offset_t w,
+      offset_t h,
+      offset_t d,
+      offset_t n) const {
+    // Get corner pixel values from (x, y, z)
+    offset_t bx0, bx1, by0, by1, bz0, bz1;
+    interpolation::bounds(interpolation0, x, bx0, bx1);
+    interpolation::bounds(interpolation1, y, by0, by1);
+    interpolation::bounds(interpolation2, z, bz0, bz1);
+    offset_t dbx = bx1 - bx0;
+    offset_t dby = by1 - by0;
+    offset_t dbz = bz1 - bz0;
+
+    // Pre-compute offsets and target value
+    scalar_t* src_ptr_NC0 = src_ptr + n * src_sN;
+    scalar_t* out_ptr_NC0 = out_ptr + n * out_sN;
+    scalar_t* out_ptr_NCXYZ0 = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+    scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+    scalar_t target[3 * MONAI_MAX_NUM_CHANNELS];
+    if (trgt_ptr && (do_push || do_grad))
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC) {
+        target[c] = *trgt_ptr_NCXYZ;
+        if (trgt_K > 1) {
+          target[c + C] = trgt_ptr_NCXYZ[trgt_sK];
+          target[c + C * 2] = trgt_ptr_NCXYZ[trgt_sK * 2];
+        }
+      }
+
+    // Initialize output
+    scalar_t* out_ptr_NCXYZ = out_ptr_NCXYZ0;
+    if (do_pull || do_sgrad) {
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC) {
+        *out_ptr_NCXYZ = static_cast<scalar_t>(0);
+        if (do_sgrad) {
+          out_ptr_NCXYZ[out_sK] = static_cast<scalar_t>(0);
+          out_ptr_NCXYZ[out_sK * 2] = static_cast<scalar_t>(0);
+        }
+      }
+    }
+
+    // Pre-compute indices/weights/grad
+    scalar_t wx[8], wy[8], wz[8]; // B-spline weights
+    scalar_t gx[8], gy[8], gz[8]; // B-spline derivatives
+    scalar_t hx[8], hy[8], hz[8]; // B-spline 2nd derivatives
+    offset_t ix[8], iy[8], iz[8]; // Warped indices
+    uint8_t sx[8], sy[8], sz[8]; // Warped indices
+
+    {
+      scalar_t *owz = static_cast<scalar_t*>(wz), *ogz = static_cast<scalar_t*>(gz), *ohz = static_cast<scalar_t*>(hz);
+      offset_t* oiz = static_cast<offset_t*>(iz);
+      uint8_t* osz = static_cast<uint8_t*>(sz);
+      for (offset_t bz = bz0; bz <= bz1; ++bz) {
+        scalar_t dz = z - bz;
+        *(owz++) = interpolation::fastweight(interpolation2, dz);
+        if (do_grad || do_sgrad)
+          *(ogz++) = interpolation::fastgrad(interpolation2, dz);
+        if (do_grad && trgt_sK > 1)
+          *(ohz++) = interpolation::fasthess(interpolation2, dz);
+        *(osz++) = bound::sign(bound2, bz, src_Z);
+        *(oiz++) = bound::index(bound2, bz, src_Z);
+      }
+    }
+    {
+      scalar_t *owy = static_cast<scalar_t*>(wy), *ogy = static_cast<scalar_t*>(gy), *ohy = static_cast<scalar_t*>(hy);
+      offset_t* oiy = static_cast<offset_t*>(iy);
+      uint8_t* osy = static_cast<uint8_t*>(sy);
+      for (offset_t by = by0; by <= by1; ++by) {
+        scalar_t dy = y - by;
+        *(owy++) = interpolation::fastweight(interpolation1, dy);
+        if (do_grad || do_sgrad)
+          *(ogy++) = interpolation::fastgrad(interpolation1, dy);
+        if (do_grad && trgt_sK > 1)
+          *(ohy++) = interpolation::fasthess(interpolation1, dy);
+        *(osy++) = bound::sign(bound1, by, src_Y);
+        *(oiy++) = bound::index(bound1, by, src_Y);
+      }
+    }
+    {
+      scalar_t *owx = static_cast<scalar_t*>(wx), *ogx = static_cast<scalar_t*>(gx), *ohx = static_cast<scalar_t*>(hx);
+      offset_t* oix = static_cast<offset_t*>(ix);
+      uint8_t* osx = static_cast<uint8_t*>(sx);
+      for (offset_t bx = bx0; bx <= bx1; ++bx) {
+        scalar_t dx = x - bx;
+        *(owx++) = interpolation::fastweight(interpolation0, dx);
+        if (do_grad || do_sgrad)
+          *(ogx++) = interpolation::fastgrad(interpolation0, dx);
+        if (do_grad && trgt_sK > 1)
+          *(ohx++) = interpolation::fasthess(interpolation0, dx);
+        *(osx++) = bound::sign(bound0, bx, src_X);
+        *(oix++) = bound::index(bound0, bx, src_X);
+      }
+    }
+
+    // Convolve coefficients with basis functions
+    scalar_t ogx, ogy, ogz;
+    ogx = ogy = ogz = static_cast<scalar_t>(0);
+    for (offset_t k = 0; k <= dbz; ++k) {
+      offset_t ooz = iz[k] * out_sZ;
+      offset_t osz = iz[k] * src_sZ;
+      uint8_t szz = sz[k];
+      scalar_t wzz = wz[k];
+      scalar_t gzz = gz[k];
+      scalar_t hzz = hz[k];
+      for (offset_t j = 0; j <= dby; ++j) {
+        offset_t ooyz = ooz + iy[j] * out_sY;
+        offset_t osyz = osz + iy[j] * src_sY;
+        uint8_t syz = szz * sy[j];
+        scalar_t wyy = wy[j];
+        scalar_t gyy = gy[j];
+        scalar_t hyy = hy[j];
+        for (offset_t i = 0; i <= dbx; ++i) {
+          offset_t ooxyz = ooyz + ix[i] * out_sX;
+          offset_t osxyz = osyz + ix[i] * src_sX;
+          uint8_t sxyz = syz * sx[i];
+          scalar_t wxx = wx[i];
+          scalar_t gxx = gx[i];
+          scalar_t hxx = hx[i];
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          if (do_pull) {
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t* out_ptr_NCXYZ = out_ptr_NCXYZ0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC)
+              *out_ptr_NCXYZ += bound::get(src_ptr_NC, osxyz, sxyz) * (wxx * wyy * wzz);
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          else if (do_sgrad) {
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t* out_ptr_NCXYZ = out_ptr_NCXYZ0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
+              scalar_t src = bound::get(src_ptr_NC, osxyz, sxyz);
+              *out_ptr_NCXYZ += src * (gxx * wyy * wzz);
+              out_ptr_NCXYZ[out_sK] += src * (wxx * gyy * wzz);
+              out_ptr_NCXYZ[2 * out_sK] += src * (wxx * wyy * gzz);
+            }
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          else if (do_push) {
+            if (trgt_K == 1) {
+              // Diff w.r.t. push/pull
+              scalar_t* out_ptr_NC = out_ptr_NC0;
+              for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+                bound::add(out_ptr_NC, ooxyz, (wxx * wyy * wzz) * target[c], sxyz);
+            } else {
+              // Diff w.r.t. sgrad
+              scalar_t* out_ptr_NC = out_ptr_NC0;
+              for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC) {
+                scalar_t val = (gxx * wyy * wzz) * target[c] + (wxx * gyy * wzz) * target[c + C] +
+                    (wxx * wyy * gzz) * target[c + C * 2];
+                bound::add(out_ptr_NC, ooxyz, val, sxyz);
+              }
+            }
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Count ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          else if (do_count) {
+            bound::add(out_ptr_NC0, ooxyz, (wxx * wyy * wzz), sxyz);
+          }
+
+          // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          if (do_grad) {
+            if (trgt_K == 1) {
+              // Diff w.r.t. pull/push
+              scalar_t* src_ptr_NC = src_ptr_NC0;
+              scalar_t dot = static_cast<scalar_t>(0);
+              for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+                scalar_t src = bound::get(src_ptr_NC, osxyz, sxyz);
+                dot += (trgt_ptr ? src * target[c] : src);
+                // trgt_ptr == 0 in the backward pass of 'count'
+              }
+              ogx += (gxx * wyy * wzz) * dot;
+              ogy += (wxx * gyy * wzz) * dot;
+              ogz += (wxx * wyy * gzz) * dot;
+            } else {
+              // Diff w.r.t. sgrad
+              scalar_t* src_ptr_NC = src_ptr_NC0;
+              scalar_t dot0, dot1, dot2;
+              dot0 = dot1 = dot2 = static_cast<scalar_t>(0);
+              for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+                scalar_t src = bound::get(src_ptr_NC, osxyz, sxyz);
+                dot0 += src * target[c];
+                dot1 += src * target[c + C];
+                dot2 += src * target[c + C * 2];
+              }
+              ogx += (hxx * wyy * wzz) * dot0 + (gxx * gyy * wzz) * dot1 + (gxx * wyy * gzz) * dot2;
+              ogy += (gxx * gyy * wzz) * dot0 + (wxx * hyy * wzz) * dot1 + (wxx * gyy * gzz) * dot2;
+              ogz += (gxx * wyy * gzz) * dot0 + (wxx * gyy * gzz) * dot1 + (wxx * wyy * hzz) * dot2;
+            }
+          }
+
+        } // x
+      } // y
+    } // z
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY + d * grad_sZ;
+      (*grad_ptr_NXYZ) = ogx;
+      grad_ptr_NXYZ[grad_sC] = ogy;
+      grad_ptr_NXYZ[grad_sC * 2] = ogz;
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     GENERIC INTERPOLATION 2D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate2d(
+      scalar_t x,
+      scalar_t y,
+      offset_t w,
+      offset_t h,
+      offset_t n) const {
+    // Get corner pixel values from (x, y)
+    offset_t bx0, bx1, by0, by1;
+    interpolation::bounds(interpolation0, x, bx0, bx1);
+    interpolation::bounds(interpolation1, y, by0, by1);
+    offset_t dbx = bx1 - bx0;
+    offset_t dby = by1 - by0;
+
+    // Pre-compute offsets and target value
+    scalar_t* src_ptr_NC0 = src_ptr + n * src_sN;
+    scalar_t* out_ptr_NC0 = out_ptr + n * out_sN;
+    scalar_t* out_ptr_NCXY0 = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+    scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+    scalar_t target[2 * MONAI_MAX_NUM_CHANNELS];
+    if (trgt_ptr && (do_push || do_grad))
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC) {
+        target[c] = *trgt_ptr_NCXY;
+        if (trgt_K > 1) {
+          target[c + C] = trgt_ptr_NCXY[trgt_sK];
+        }
+      }
+
+    // Initialize output
+    scalar_t* out_ptr_NCXY = out_ptr_NCXY0;
+    if (do_pull || do_sgrad) {
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC) {
+        *out_ptr_NCXY = static_cast<scalar_t>(0);
+        if (do_sgrad) {
+          out_ptr_NCXY[out_sK] = static_cast<scalar_t>(0);
+        }
+      }
+    }
+
+    // Pre-compute indices/weights/grad
+    scalar_t wx[8], wy[8]; // B-spline weights
+    scalar_t gx[8], gy[8]; // B-spline derivatives
+    scalar_t hx[8], hy[8]; // B-spline 2nd derivatives
+    offset_t ix[8], iy[8]; // Warped indices
+    uint8_t sx[8], sy[8]; // Warped indices
+
+    {
+      scalar_t *owy = static_cast<scalar_t*>(wy), *ogy = static_cast<scalar_t*>(gy), *ohy = static_cast<scalar_t*>(hy);
+      offset_t* oiy = static_cast<offset_t*>(iy);
+      uint8_t* osy = static_cast<uint8_t*>(sy);
+      for (offset_t by = by0; by <= by1; ++by) {
+        scalar_t dy = y - by;
+        *(owy++) = interpolation::fastweight(interpolation1, dy);
+        if (do_grad || do_sgrad)
+          *(ogy++) = interpolation::fastgrad(interpolation1, dy);
+        if (do_grad && trgt_sK > 1)
+          *(ohy++) = interpolation::fasthess(interpolation1, dy);
+        *(osy++) = bound::sign(bound1, by, src_Y);
+        *(oiy++) = bound::index(bound1, by, src_Y);
+      }
+    }
+    {
+      scalar_t *owx = static_cast<scalar_t*>(wx), *ogx = static_cast<scalar_t*>(gx), *ohx = static_cast<scalar_t*>(hx);
+      offset_t* oix = static_cast<offset_t*>(ix);
+      uint8_t* osx = static_cast<uint8_t*>(sx);
+      for (offset_t bx = bx0; bx <= bx1; ++bx) {
+        scalar_t dx = x - bx;
+        *(owx++) = interpolation::fastweight(interpolation0, dx);
+        if (do_grad || do_sgrad)
+          *(ogx++) = interpolation::fastgrad(interpolation0, dx);
+        if (do_grad && trgt_sK > 1)
+          *(ohx++) = interpolation::fasthess(interpolation0, dx);
+        *(osx++) = bound::sign(bound0, bx, src_X);
+        *(oix++) = bound::index(bound0, bx, src_X);
+      }
+    }
+
+    // Convolve coefficients with basis functions
+    scalar_t ogx, ogy;
+    ogx = ogy = static_cast<scalar_t>(0);
+    for (offset_t j = 0; j <= dby; ++j) {
+      offset_t ooy = iy[j] * out_sY;
+      offset_t osy = iy[j] * src_sY;
+      uint8_t syy = sy[j];
+      scalar_t wyy = wy[j];
+      scalar_t gyy = gy[j];
+      scalar_t hyy = hy[j];
+      for (offset_t i = 0; i <= dbx; ++i) {
+        offset_t ooxy = ooy + ix[i] * out_sX;
+        offset_t osxy = osy + ix[i] * src_sX;
+        uint8_t sxy = syy * sx[i];
+        scalar_t wxx = wx[i];
+        scalar_t gxx = gx[i];
+        scalar_t hxx = hx[i];
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        if (do_pull) {
+          scalar_t* src_ptr_NC = src_ptr_NC0;
+          scalar_t* out_ptr_NCXY = out_ptr_NCXY0;
+          for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC)
+            *out_ptr_NCXY += bound::get(src_ptr_NC, osxy, sxy) * (wxx * wyy);
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        else if (do_sgrad) {
+          scalar_t* src_ptr_NC = src_ptr_NC0;
+          scalar_t* out_ptr_NCXY = out_ptr_NCXY0;
+          for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
+            scalar_t src = bound::get(src_ptr_NC, osxy, sxy);
+            *out_ptr_NCXY += src * (gxx * wyy);
+            out_ptr_NCXY[out_sK] += src * (wxx * gyy);
+          }
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        else if (do_push) {
+          if (trgt_K == 1) {
+            // Diff w.r.t. push/pull
+            scalar_t* out_ptr_NC = out_ptr_NC0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+              bound::add(out_ptr_NC, ooxy, (wxx * wyy) * target[c], sxy);
+          } else {
+            // Diff w.r.t. sgrad
+            scalar_t* out_ptr_NC = out_ptr_NC0;
+            for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC) {
+              scalar_t val = (gxx * wyy) * target[c] + (wxx * gyy) * target[c + C];
+              bound::add(out_ptr_NC, ooxy, val, sxy);
+            }
+          }
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Count ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        else if (do_count) {
+          bound::add(out_ptr_NC0, ooxy, (wxx * wyy), sxy);
+        }
+
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        if (do_grad) {
+          if (trgt_K == 1) {
+            // Diff w.r.t. pull/push
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t dot = static_cast<scalar_t>(0);
+            for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+              scalar_t src = bound::get(src_ptr_NC, osxy, sxy);
+              dot += (trgt_ptr ? src * target[c] : src);
+              // trgt_ptr == 0 in the backward pass of 'count'
+            }
+            ogx += (gxx * wyy) * dot;
+            ogy += (wxx * gyy) * dot;
+          } else {
+            // Diff w.r.t. sgrad
+            scalar_t* src_ptr_NC = src_ptr_NC0;
+            scalar_t dot0, dot1;
+            dot0 = dot1 = static_cast<scalar_t>(0);
+            for (offset_t c = 0; c < C; ++c, src_ptr_NC += src_sC) {
+              scalar_t src = bound::get(src_ptr_NC, osxy, sxy);
+              dot0 += src * target[c];
+              dot1 += src * target[c + C];
+            }
+            ogx += (hxx * wyy) * dot0 + (gxx * gyy) * dot1;
+            ogy += (gxx * gyy) * dot0 + (wxx * hyy) * dot1;
+          }
+        }
+
+      } // x
+    } // y
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Grad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      scalar_t* grad_ptr_NXY = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY;
+      (*grad_ptr_NXY) = ogx;
+      grad_ptr_NXY[grad_sC] = ogy;
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     LINEAR INTERPOLATION 3D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate3d_trilinear(
+      scalar_t x,
+      scalar_t y,
+      scalar_t z,
+      offset_t w,
+      offset_t h,
+      offset_t d,
+      offset_t n) const {
+    // Get corner pixel values from (x, y, z)
+    offset_t ix0 = static_cast<offset_t>(std::floor(x));
+    offset_t iy0 = static_cast<offset_t>(std::floor(y));
+    offset_t iz0 = static_cast<offset_t>(std::floor(z));
+
+    // Interpolation weights (inversely proportional to distance)
+    scalar_t dx1 = x - ix0;
+    scalar_t dy1 = y - iy0;
+    scalar_t dz1 = z - iz0;
+    scalar_t dx0 = 1. - dx1;
+    scalar_t dy0 = 1. - dy1;
+    scalar_t dz0 = 1. - dz1;
+    scalar_t w000 = dx0 * dy0 * dz0;
+    scalar_t w100 = dx1 * dy0 * dz0;
+    scalar_t w010 = dx0 * dy1 * dz0;
+    scalar_t w001 = dx0 * dy0 * dz1;
+    scalar_t w110 = dx1 * dy1 * dz0;
+    scalar_t w011 = dx0 * dy1 * dz1;
+    scalar_t w101 = dx1 * dy0 * dz1;
+    scalar_t w111 = dx1 * dy1 * dz1;
+
+    // Sign (/!\ compute sign before warping indices)
+    int8_t sx1 = bound::sign(bound0, ix0 + 1, src_X);
+    int8_t sy1 = bound::sign(bound1, iy0 + 1, src_Y);
+    int8_t sz1 = bound::sign(bound2, iz0 + 1, src_Z);
+    int8_t sx0 = bound::sign(bound0, ix0, src_X);
+    int8_t sy0 = bound::sign(bound1, iy0, src_Y);
+    int8_t sz0 = bound::sign(bound2, iz0, src_Z);
+    int8_t s000 = sx0 * sy0 * sz0;
+    int8_t s100 = sx1 * sy0 * sz0;
+    int8_t s010 = sx0 * sy1 * sz0;
+    int8_t s001 = sx0 * sy0 * sz1;
+    int8_t s110 = sx1 * sy1 * sz0;
+    int8_t s011 = sx0 * sy1 * sz1;
+    int8_t s101 = sx1 * sy0 * sz1;
+    int8_t s111 = sx1 * sy1 * sz1;
+
+    // Warp indices
+    offset_t ix1, iy1, iz1;
+    ix1 = bound::index(bound0, ix0 + 1, src_X);
+    iy1 = bound::index(bound1, iy0 + 1, src_Y);
+    iz1 = bound::index(bound2, iz0 + 1, src_Z);
+    ix0 = bound::index(bound0, ix0, src_X);
+    iy0 = bound::index(bound1, iy0, src_Y);
+    iz0 = bound::index(bound2, iz0, src_Z);
+
+    // Offsets into source volume
+    offset_t o000, o100, o010, o001, o110, o011, o101, o111;
+
+    if (do_pull || do_grad || do_sgrad) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      scalar_t gx = static_cast<scalar_t>(0);
+      scalar_t gy = static_cast<scalar_t>(0);
+      scalar_t gz = static_cast<scalar_t>(0);
+      scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      if (trgt_K == 1) {
+        // backward w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt = trgt_ptr ? *trgt_ptr_NCXYZ : static_cast<scalar_t>(1);
+          // ^ trgt_ptr == 0 during the backward pass of count
+          src = bound::get(src_ptr_NC, o000, s000);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy0 * dz0 * src;
+          gy -= dx0 * dz0 * src;
+          gz -= dx0 * dy0 * src;
+          src = bound::get(src_ptr_NC, o100, s100);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy0 * dz0 * src;
+          gy -= dx1 * dz0 * src;
+          gz -= dx1 * dy0 * src;
+          src = bound::get(src_ptr_NC, o010, s010);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy1 * dz0 * src;
+          gy += dx0 * dz0 * src;
+          gz -= dx0 * dy1 * src;
+          src = bound::get(src_ptr_NC, o110, s110);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy1 * dz0 * src;
+          gy += dx1 * dz0 * src;
+          gz -= dx1 * dy1 * src;
+          src = bound::get(src_ptr_NC, o001, s001);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy0 * dz1 * src;
+          gy -= dx0 * dz1 * src;
+          gz += dx0 * dy0 * src;
+          src = bound::get(src_ptr_NC, o101, s101);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy0 * dz1 * src;
+          gy -= dx1 * dz1 * src;
+          gz += dx1 * dy0 * src;
+          src = bound::get(src_ptr_NC, o011, s011);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy1 * dz1 * src;
+          gy += dx0 * dz1 * src;
+          gz += dx0 * dy1 * src;
+          src = bound::get(src_ptr_NC, o111, s111);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy1 * dz1 * src;
+          gy += dx1 * dz1 * src;
+          gz += dx1 * dy1 * src;
+        }
+      } else {
+        // backward w.r.t. sgrad
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt0 = *trgt_ptr_NCXYZ, trgt1 = trgt_ptr_NCXYZ[trgt_sK], trgt2 = trgt_ptr_NCXYZ[trgt_sK * 2];
+          src = bound::get(src_ptr_NC, o000, s000);
+          gx += (dz0 * trgt1 + dy0 * trgt2) * src;
+          gy += (dz0 * trgt0 + dx0 * trgt2) * src;
+          gz += (dy0 * trgt0 + dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o100, s100);
+          gx += (-dz0 * trgt1 - dy0 * trgt2) * src;
+          gy += (-dz0 * trgt0 + dx1 * trgt2) * src;
+          gz += (-dy0 * trgt0 + dx1 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o010, s010);
+          gx += (-dz0 * trgt1 + dy1 * trgt2) * src;
+          gy += (-dz0 * trgt0 - dx0 * trgt2) * src;
+          gz += (dy1 * trgt0 - dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o110, s110);
+          gx += (dz0 * trgt1 - dy1 * trgt2) * src;
+          gy += (dz0 * trgt0 - dx1 * trgt2) * src;
+          gz += (-dy1 * trgt0 - dx1 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o001, s001);
+          gx += (dz1 * trgt1 - dy0 * trgt2) * src;
+          gy += (dz1 * trgt0 - dx0 * trgt2) * src;
+          gz += (-dy0 * trgt0 - dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o101, s101);
+          gx += (-dz1 * trgt1 + dy0 * trgt2) * src;
+          gy += (-dz1 * trgt0 - dx1 * trgt2) * src;
+          gz += (dy0 * trgt0 - dx1 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o011, s011);
+          gx += (-dz1 * trgt1 - dy1 * trgt2) * src;
+          gy += (-dz1 * trgt0 + dx0 * trgt2) * src;
+          gz += (-dy1 * trgt0 + dx0 * trgt1) * src;
+          src = bound::get(src_ptr_NC, o111, s111);
+          gx += (dz1 * trgt1 + dy1 * trgt2) * src;
+          gy += (dz1 * trgt0 + dx1 * trgt2) * src;
+          gz += (dy1 * trgt0 + dx1 * trgt1) * src;
+        }
+      }
+
+      scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY + d * grad_sZ;
+      (*grad_ptr_NXYZ) = gx;
+      grad_ptr_NXYZ[grad_sC] = gy;
+      grad_ptr_NXYZ[grad_sC * 2] = gz;
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_pull) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
+        *out_ptr_NCXYZ = bound::get(src_ptr_NC, o000, s000) * w000 + bound::get(src_ptr_NC, o100, s100) * w100 +
+            bound::get(src_ptr_NC, o010, s010) * w010 + bound::get(src_ptr_NC, o110, s110) * w110 +
+            bound::get(src_ptr_NC, o001, s001) * w001 + bound::get(src_ptr_NC, o101, s101) * w101 +
+            bound::get(src_ptr_NC, o011, s011) * w011 + bound::get(src_ptr_NC, o111, s111) * w111;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
+    else if (do_sgrad) {
+      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
+      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
+      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
+      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+      scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
+        scalar_t src000 = bound::get(src_ptr_NC, o000, s000);
+        scalar_t src100 = bound::get(src_ptr_NC, o100, s100);
+        scalar_t src010 = bound::get(src_ptr_NC, o010, s010);
+        scalar_t src110 = bound::get(src_ptr_NC, o110, s110);
+        scalar_t src001 = bound::get(src_ptr_NC, o001, s001);
+        scalar_t src101 = bound::get(src_ptr_NC, o101, s101);
+        scalar_t src011 = bound::get(src_ptr_NC, o011, s011);
+        scalar_t src111 = bound::get(src_ptr_NC, o111, s111);
+        *out_ptr_NCXYZ = -dy0 * dz0 * src000 + dy0 * dz0 * src100 - dy1 * dz0 * src010 + dy1 * dz0 * src110 -
+            dy0 * dz1 * src001 + dy0 * dz1 * src101 - dy1 * dz1 * src011 + dy1 * dz1 * src111;
+        out_ptr_NCXYZ[out_sK] = -dx0 * dz0 * src000 - dx1 * dz0 * src100 + dx0 * dz0 * src010 + dx1 * dz0 * src110 -
+            dx0 * dz1 * src001 - dx1 * dz1 * src101 + dx0 * dz1 * src011 + dx1 * dz1 * src111;
+        out_ptr_NCXYZ[out_sK * 2] = -dx0 * dy0 * src000 - dx1 * dy0 * src100 - dx0 * dy1 * src010 - dx1 * dy1 * src110 +
+            dx0 * dy0 * src001 + dx1 * dy0 * src101 + dx0 * dy1 * src011 + dx1 * dy1 * src111;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_push) {
+      // Offsets into 'push' volume
+      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      if (trgt_K == 1) {
+        // Diff w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt = *trgt_ptr_NCXYZ;
+          bound::add(out_ptr_NC, o000, w000 * trgt, s000);
+          bound::add(out_ptr_NC, o100, w100 * trgt, s100);
+          bound::add(out_ptr_NC, o010, w010 * trgt, s010);
+          bound::add(out_ptr_NC, o110, w110 * trgt, s110);
+          bound::add(out_ptr_NC, o001, w001 * trgt, s001);
+          bound::add(out_ptr_NC, o101, w101 * trgt, s101);
+          bound::add(out_ptr_NC, o011, w011 * trgt, s011);
+          bound::add(out_ptr_NC, o111, w111 * trgt, s111);
+        }
+      } else {
+        // Diff w.r.t. sgrad
+        scalar_t val;
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt0 = *trgt_ptr_NCXYZ, trgt1 = trgt_ptr_NCXYZ[trgt_sK], trgt2 = trgt_ptr_NCXYZ[trgt_sK * 2];
+          val = -dy0 * dz0 * trgt0 - dx0 * dz0 * trgt1 - dx0 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o000, val, s000);
+          val = dy0 * dz0 * trgt0 - dx1 * dz0 * trgt1 - dx1 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o100, val, s100);
+          val = -dy1 * dz0 * trgt0 + dx0 * dz0 * trgt1 - dx0 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o010, val, s010);
+          val = dy1 * dz0 * trgt0 + dx1 * dz0 * trgt1 - dx1 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o110, val, s110);
+          val = -dy0 * dz1 * trgt0 - dx0 * dz1 * trgt1 + dx0 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o001, val, s001);
+          val = dy0 * dz1 * trgt0 - dx1 * dz1 * trgt1 + dx1 * dy0 * trgt2;
+          bound::add(out_ptr_NC, o101, val, s101);
+          val = -dy1 * dz1 * trgt0 + dx0 * dz1 * trgt1 + dx0 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o011, val, s011);
+          val = dy1 * dz1 * trgt0 + dx1 * dz1 * trgt1 + dx1 * dy1 * trgt2;
+          bound::add(out_ptr_NC, o111, val, s111);
+        }
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_count) {
+      // Offsets into 'push' volume
+      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+
+      scalar_t* out_ptr_N = out_ptr + n * out_sN;
+      bound::add(out_ptr_N, o000, w000, s000);
+      bound::add(out_ptr_N, o100, w100, s100);
+      bound::add(out_ptr_N, o010, w010, s010);
+      bound::add(out_ptr_N, o110, w110, s110);
+      bound::add(out_ptr_N, o001, w001, s001);
+      bound::add(out_ptr_N, o101, w101, s101);
+      bound::add(out_ptr_N, o011, w011, s011);
+      bound::add(out_ptr_N, o111, w111, s111);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                     LINEAR INTERPOLATION 2D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate2d_bilinear(
+      scalar_t x,
+      scalar_t y,
+      offset_t w,
+      offset_t h,
+      offset_t n) const {
+    // Get corner pixel values from (x, y, z)
+    offset_t ix0 = static_cast<offset_t>(std::floor(x));
+    offset_t iy0 = static_cast<offset_t>(std::floor(y));
+
+    // Interpolation weights (inversely proportional to distance)
+    scalar_t dx1 = x - ix0;
+    scalar_t dy1 = y - iy0;
+    scalar_t dx0 = 1. - dx1;
+    scalar_t dy0 = 1. - dy1;
+    scalar_t w00 = dx0 * dy0;
+    scalar_t w10 = dx1 * dy0;
+    scalar_t w01 = dx0 * dy1;
+    scalar_t w11 = dx1 * dy1;
+    ;
+
+    // Sign (/!\ compute sign before warping indices)
+    int8_t sx1 = bound::sign(bound0, ix0 + 1, src_X);
+    int8_t sy1 = bound::sign(bound1, iy0 + 1, src_Y);
+    int8_t sx0 = bound::sign(bound0, ix0, src_X);
+    int8_t sy0 = bound::sign(bound1, iy0, src_Y);
+    int8_t s00 = sx0 * sy0;
+    int8_t s10 = sx1 * sy0;
+    int8_t s01 = sx0 * sy1;
+    int8_t s11 = sx1 * sy1;
+
+    // Warp indices
+    offset_t ix1, iy1;
+    ix1 = bound::index(bound0, ix0 + 1, src_X);
+    iy1 = bound::index(bound1, iy0 + 1, src_Y);
+    ix0 = bound::index(bound0, ix0, src_X);
+    iy0 = bound::index(bound1, iy0, src_Y);
+
+    // Offsets into source volume
+    offset_t o00, o10, o01, o11;
+    if (do_pull || do_grad || do_sgrad) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_grad) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+      scalar_t gx = static_cast<scalar_t>(0);
+      scalar_t gy = static_cast<scalar_t>(0);
+      scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      if (trgt_K == 1) {
+        // backward w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt = trgt_ptr ? *trgt_ptr_NCXY : static_cast<scalar_t>(1);
+          // ^ trgt_ptr == 0 during the backward pass of count
+          src = bound::get(src_ptr_NC, o00, s00);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy0 * src;
+          gy -= dx0 * src;
+          src = bound::get(src_ptr_NC, o10, s10);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy0 * src;
+          gy -= dx1 * src;
+          src = bound::get(src_ptr_NC, o01, s01);
+          if (trgt_ptr)
+            src *= trgt;
+          gx -= dy1 * src;
+          gy += dx0 * src;
+          src = bound::get(src_ptr_NC, o11, s11);
+          if (trgt_ptr)
+            src *= trgt;
+          gx += dy1 * src;
+          gy += dx1 * src;
+        }
+      } else {
+        // backward w.r.t. sgrad
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, src_ptr_NC += src_sC) {
+          scalar_t src;
+          scalar_t trgt0 = *trgt_ptr_NCXY, trgt1 = trgt_ptr_NCXY[trgt_sK];
+          src = bound::get(src_ptr_NC, o00, s00);
+          gx += trgt1 * src;
+          gy += trgt0 * src;
+          src = bound::get(src_ptr_NC, o10, s10);
+          gx -= trgt1 * src;
+          gy -= trgt0 * src;
+          src = bound::get(src_ptr_NC, o01, s01);
+          gx -= trgt1 * src;
+          gy -= trgt0 * src;
+          src = bound::get(src_ptr_NC, o11, s11);
+          gx += trgt1 * src;
+          gy += trgt0 * src;
+        }
+      }
+
+      scalar_t* grad_ptr_NXYZ = grad_ptr + n * grad_sN + w * grad_sX + h * grad_sY;
+      (*grad_ptr_NXYZ) = gx;
+      grad_ptr_NXYZ[grad_sC] = gy;
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (do_pull) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+      scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
+        *out_ptr_NCXY = bound::get(src_ptr_NC, o00, s00) * w00 + bound::get(src_ptr_NC, o10, s10) * w10 +
+            bound::get(src_ptr_NC, o01, s01) * w01 + bound::get(src_ptr_NC, o11, s11) * w11;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_sgrad) {
+      o00 = ix0 * src_sX + iy0 * src_sY;
+      o10 = ix1 * src_sX + iy0 * src_sY;
+      o01 = ix0 * src_sX + iy1 * src_sY;
+      o11 = ix1 * src_sX + iy1 * src_sY;
+      scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
+        scalar_t src00 = bound::get(src_ptr_NC, o00, s00);
+        scalar_t src10 = bound::get(src_ptr_NC, o10, s10);
+        scalar_t src01 = bound::get(src_ptr_NC, o01, s01);
+        scalar_t src11 = bound::get(src_ptr_NC, o11, s11);
+        *out_ptr_NCXY = -dy0 * src00 + dy0 * src10 - dy1 * src01 + dy1 * src11;
+        out_ptr_NCXY[out_sK] = -dx0 * src00 - dx1 * src10 + dx0 * src01 + dx1 * src11;
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_push) {
+      // Offsets into 'push' volume
+      o00 = ix0 * out_sX + iy0 * out_sY;
+      o10 = ix1 * out_sX + iy0 * out_sY;
+      o01 = ix0 * out_sX + iy1 * out_sY;
+      o11 = ix1 * out_sX + iy1 * out_sY;
+      scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      if (trgt_K == 1) {
+        // Diff w.r.t. push/pull
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt = *trgt_ptr_NCXY;
+          bound::add(out_ptr_NC, o00, w00 * trgt, s00);
+          bound::add(out_ptr_NC, o10, w10 * trgt, s10);
+          bound::add(out_ptr_NC, o01, w01 * trgt, s01);
+          bound::add(out_ptr_NC, o11, w11 * trgt, s11);
+        }
+      } else {
+        // Diff w.r.t. sgrad
+        scalar_t val;
+        for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, out_ptr_NC += out_sC) {
+          scalar_t trgt0 = *trgt_ptr_NCXY, trgt1 = trgt_ptr_NCXY[trgt_sK];
+          val = -dy0 * trgt0 - dx0 * trgt1;
+          bound::add(out_ptr_NC, o00, val, s00);
+          val = dy0 * trgt0 - dx1 * trgt1;
+          bound::add(out_ptr_NC, o10, val, s10);
+          val = -dy1 * trgt0 + dx0 * trgt1;
+          bound::add(out_ptr_NC, o01, val, s01);
+          val = dy1 * trgt0 + dx1 * trgt1;
+          bound::add(out_ptr_NC, o11, val, s11);
+        }
+      }
+    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else if (do_count) {
+      // Offsets into 'push' volume
+      o00 = ix0 * out_sX + iy0 * out_sY;
+      o10 = ix1 * out_sX + iy0 * out_sY;
+      o01 = ix0 * out_sX + iy1 * out_sY;
+      o11 = ix1 * out_sX + iy1 * out_sY;
+
+      scalar_t* out_ptr_N = out_ptr + n * out_sN;
+      bound::add(out_ptr_N, o00, w00, s00);
+      bound::add(out_ptr_N, o10, w10, s10);
+      bound::add(out_ptr_N, o01, w01, s01);
+      bound::add(out_ptr_N, o11, w11, s11);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                  NEAREST NEIGHBOR INTERPOLATION 3D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate3d_nearest(
+      scalar_t x,
+      scalar_t y,
+      scalar_t z,
+      offset_t w,
+      offset_t h,
+      offset_t d,
+      offset_t n) const {
+    offset_t ix = static_cast<offset_t>(std::round(x));
+    offset_t iy = static_cast<offset_t>(std::round(y));
+    offset_t iz = static_cast<offset_t>(std::round(z));
+
+    // Boundary condition (/!\ compute sign before warping indices)
+    int8_t sx = bound::sign(bound0, ix, src_X);
+    int8_t sy = bound::sign(bound1, iy, src_Y);
+    int8_t sz = bound::sign(bound2, iz, src_Z);
+    ix = bound::index(bound0, ix, src_X);
+    iy = bound::index(bound1, iy, src_Y);
+    iz = bound::index(bound2, iz, src_Z);
+
+    // Sign
+    int8_t s = sz * sy * sx;
+
+    if (do_pull) {
+      offset_t o = iz * src_sZ + iy * src_sY + ix * src_sX;
+      scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC)
+        *out_ptr_NCXYZ = bound::get(src_ptr_NC, o, s);
+    } else if (do_push && trgt_K == 1) {
+      offset_t o = iz * out_sZ + iy * out_sY + ix * out_sX;
+      scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXYZ += trgt_sC, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, *trgt_ptr_NCXYZ, s);
+    } else if (do_count) {
+      offset_t o = iz * out_sZ + iy * out_sY + ix * out_sX;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, static_cast<scalar_t>(1), s);
+    }
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                  NEAREST NEIGHBOR INTERPOLATION 2D
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  template <typename scalar_t, typename offset_t>
+  MONAI_DEVICE void PushPullImpl<scalar_t, offset_t>::interpolate2d_nearest(
+      scalar_t x,
+      scalar_t y,
+      offset_t w,
+      offset_t h,
+      offset_t n) const {
+    offset_t ix = static_cast<offset_t>(std::round(x));
+    offset_t iy = static_cast<offset_t>(std::round(y));
+
+    // Boundary condition (/!\ compute sign before warping indices)
+    int8_t sx = bound::sign(bound0, ix, src_X);
+    int8_t sy = bound::sign(bound1, iy, src_Y);
+    ix = bound::index(bound0, ix, src_X);
+    iy = bound::index(bound1, iy, src_Y);
+
+    // Sign
+    int8_t s = sy * sx;
+
+    if (do_pull) {
+      offset_t o = iy * src_sY + ix * src_sX;
+      scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
+      scalar_t* src_ptr_NC = src_ptr + n * src_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC)
+        *out_ptr_NCXY = bound::get(src_ptr_NC, o, s);
+    } else if (do_push && trgt_K == 1) {
+      offset_t o = iy * out_sY + ix * out_sX;
+      scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, trgt_ptr_NCXY += trgt_sC, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, *trgt_ptr_NCXY, s);
+    } else if (do_count) {
+      offset_t o = iy * out_sY + ix * out_sX;
+      scalar_t* out_ptr_NC = out_ptr + n * out_sN;
+      for (offset_t c = 0; c < C; ++c, out_ptr_NC += out_sC)
+        bound::add(out_ptr_NC, o, static_cast<scalar_t>(1), s);
+    }
+  }
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //            LINEAR INTERPOLATION 3D + SLIDING BOUNDARY
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // TODO
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                  CUDA KERNEL (MUST BE OUT OF CLASS)
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  // CUDA Kernel
+  template <typename scalar_t, typename offset_t>
+  C10_LAUNCH_BOUNDS_1(1024)
+  __global__ void pushpull_kernel(PushPullImpl<scalar_t, offset_t> f) {
+    f.loop(threadIdx.x, blockIdx.x, blockDim.x, gridDim.x);
+  }
+
+  } // namespace
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //                    FUNCTIONAL FORM WITH DISPATCH
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#define PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, SourceType0) \
+  template std::deque<Tensor> pushpull(                                    \
+      const SourceType0&,                                                  \
+      const Tensor&,                                                       \
+      const Tensor&,                                                       \
+      BoundType0,                                                          \
+      InterpolationType0,                                                  \
+      bool,                                                                \
+      bool,                                                                \
+      bool,                                                                \
+      bool,                                                                \
+      bool,                                                                \
+      bool);                                                               \
+  template std::deque<Tensor> pushpull(                                    \
+      const SourceType0&, const Tensor&, BoundType0, InterpolationType0, bool, bool, bool, bool, bool, bool)
+#define PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType0)         \
+  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, IntArrayRef); \
+  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, Tensor)
+#define PUSHPULL_INSTANTIATE1(BoundType0)               \
+  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType); \
+  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationVectorRef)
+#define PUSHPULL_INSTANTIATE        \
+  PUSHPULL_INSTANTIATE1(BoundType); \
+  PUSHPULL_INSTANTIATE1(BoundVectorRef)
+
+  // ~~~ CUDA ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  // Two arguments (source, grid)
+  // > `bound` and `interpolation` can be single arguments or vectors.
+  template <typename BoundType, typename InterpolationType, typename SourceType>
+  MONAI_HOST std::deque<Tensor> pushpull(
+      const SourceType& source,
+      const Tensor& grid,
+      BoundType bound,
+      InterpolationType interpolation,
+      bool extrapolate,
+      bool do_pull,
+      bool do_push,
+      bool do_count,
+      bool do_grad,
+      bool do_sgrad) {
+    return AT_DISPATCH_FLOATING_TYPES_AND_HALF(grid.scalar_type(), "pushpull", [&] {
+      PushPullImpl<scalar_t, int64_t> f(
+          grid.dim() - 2, bound, interpolation, extrapolate, do_pull, do_push, do_count, do_grad, do_sgrad);
+      f.ioset(source, grid);
+      pushpull_kernel<<<GET_BLOCKS(f.voxcount()), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(f);
+      return f.output;
+    });
+  }
+
+  // Three arguments (source, grid, target)
+  // > `bound` and `interpolation` can be single arguments or vectors.
+  // > `source` can be a tensor or a vector of dimensions.
+  template <typename BoundType, typename InterpolationType, typename SourceType>
+  MONAI_HOST std::deque<Tensor> pushpull(
+      const SourceType& source,
+      const Tensor& grid,
+      const Tensor& target,
+      BoundType bound,
+      InterpolationType interpolation,
+      bool extrapolate,
+      bool do_pull,
+      bool do_push,
+      bool do_count,
+      bool do_grad,
+      bool do_sgrad) {
+    return AT_DISPATCH_FLOATING_TYPES_AND_HALF(grid.scalar_type(), "pushpull", [&] {
+      PushPullImpl<scalar_t, int64_t> f(
+          grid.dim() - 2, bound, interpolation, extrapolate, do_pull, do_push, do_count, do_grad, do_sgrad);
+      f.ioset(source, grid, target);
+      pushpull_kernel<<<GET_BLOCKS(f.voxcount()), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(f);
+      return f.output;
+    });
+  }
+
+  PUSHPULL_INSTANTIATE;
+
+} // namespace <device>
+
+} // namespace monai

--- a/monai/csrc/utils/common_utils.h
+++ b/monai/csrc/utils/common_utils.h
@@ -19,3 +19,63 @@ limitations under the License.
 #define CHECK_CONTIGUOUS_CUDA(x) \
   CHECK_CUDA(x);                 \
   CHECK_CONTIGUOUS(x)
+#define CHECK_DEFINED(value) \
+  TORCH_CHECK(value.defined(), "(): expected " #value " not be undefined, but it is ", value);
+#define CHECK_STRIDED(value)                                              \
+  TORCH_CHECK(                                                            \
+      value.layout() == at::kStrided,                                     \
+      "(): expected " #value "to have torch.strided layout, but it has ", \
+      value.layout());
+#define CHECK_SPATIAL_2D_OR_3D(value)                               \
+  TORCH_CHECK(                                                      \
+      (value.dim() == 4 || value.dim() == 5),                       \
+      "(): expected 4D or 5D " #value " but got input with sizes ", \
+      value.sizes());
+#define CHECK_GRID_COMPONENT(value, dim)           \
+  TORCH_CHECK(                                     \
+      value.size(-1) == dim - 2,                   \
+      "(): expected " #value " to have size ",     \
+      dim - 2,                                     \
+      " in last "                                  \
+      "dimension, but got " #value " with sizes ", \
+      value.sizes());
+#define CHECK_SAME_DEVICE(value1, value2)     \
+  TORCH_CHECK(                                \
+      value1.device() == value2.device(),     \
+      "(): expected " #value2 " and " #value2 \
+      " to be on same device, "               \
+      "but " #value2 " is on ",               \
+      value1.device(),                        \
+      " and " #value2 " is on ",              \
+      value2.device());
+#define CHECK_SAME_DTYPE(value1, value2)      \
+  TORCH_CHECK(                                \
+      value1.dtype() == value2.dtype(),       \
+      "(): expected " #value2 " and " #value2 \
+      " to have the same dtype, "             \
+      "but " #value2 " has ",                 \
+      value1.dtype(),                         \
+      " and " #value2 " has ",                \
+      value2.dtype());
+#define CHECK_SPATIAL_NOT_EMPTY(value)                                                        \
+  for (int64_t i = 2; i < value.dim(); i++) {                                                 \
+    TORCH_CHECK(                                                                              \
+        value.size(i) > 0,                                                                    \
+        "(): expected " #value " to have non-empty spatial dimensions, but input has sizes ", \
+        value.sizes(),                                                                        \
+        " with dimension ",                                                                   \
+        i,                                                                                    \
+        " being empty");                                                                      \
+  }
+#define CHECK_GRID_TARGET_COMPAT(value1, value2)                                                                  \
+  TORCH_CHECK(                                                                                                    \
+      value2.size(0) == value1.size(0) && value2.size(2) == value1.size(1) && value2.size(3) == value1.size(2) && \
+          (value2.dim() == 4 || value2.size(4) == value1.size(3)),                                                \
+      "(): expected " #value2 " and " #value1                                                                     \
+      " to have same batch, width, height and (optionally) depth sizes, but got " #value2 " with sizes ",         \
+      value2.sizes(),                                                                                             \
+      " and " #value1 " with sizes ",                                                                             \
+      value1.sizes());
+#define CHECK_SPATIAL_LENGTH(value, dim) \
+  TORCH_CHECK(((int64_t)(value.size()) == dim - 2), "(): expected ", dim, #value " elements but got ", value.size());
+#define CHECK_VEC_NOT_EMPTY(value) TORCH_CHECK(!value.empty(), "(): expected nonempty value " #value);

--- a/monai/csrc/utils/resample_utils.h
+++ b/monai/csrc/utils/resample_utils.h
@@ -1,0 +1,149 @@
+/*
+Copyright 2020 MONAI Consortium
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// We need to define AT_PARALLEL_OPENMP (even if -fopenmp is
+// not used) so that at::parallel_for is defined somewhere.
+// This must be done before <ATen/Parallel.h> is included.
+//
+// Note that if AT_PARALLEL_OPENMP = 1 but compilation does not use
+// -fopenmp, omp pragmas will be ignored. In that case, the code will
+// be effectively sequential, and we don't have to worry about
+// operations being atomic.
+#if !(AT_PARALLEL_OPENMP)
+#if !(AT_PARALLEL_NATIVE)
+#if !(AT_PARALLEL_NATIVE_TBB)
+#error No parallel backend specified
+#endif
+#endif
+#endif
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// These are defines that help writing generic code for both GPU and CPU
+#ifdef __CUDACC__
+#include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <THC/THCAtomics.cuh>
+#define MONAI_INLINE __forceinline__
+#define MONAI_DEVICE __device__
+#define MONAI_HOST __host__
+#define MONAI_ATOMIC_ADD monai::gpuAtomicAdd
+#define MONAI_NAMESPACE_DEVICE namespace cuda
+namespace monai {
+// atomicAdd API changed between pytorch 1.4 and 1.5.
+template <typename scalar_t, typename offset_t>
+static __forceinline__ __device__ void gpuAtomicAdd(scalar_t* ptr, offset_t offset, scalar_t value) {
+#if MONAI_TORCH_VERSION >= 10500
+  ::gpuAtomicAdd(ptr + offset, value);
+#else
+  ::atomicAdd(ptr + offset, value);
+#endif
+}
+} // namespace monai
+#else
+#define MONAI_INLINE inline
+#define MONAI_DEVICE
+#define MONAI_HOST
+#define MONAI_ATOMIC_ADD monai::cpuAtomicAdd
+#define MONAI_NAMESPACE_DEVICE namespace cpu
+namespace monai {
+template <typename scalar_t, typename offset_t>
+static inline void cpuAtomicAdd(scalar_t* ptr, offset_t offset, scalar_t value) {
+#if AT_PARALLEL_OPENMP
+#pragma omp atomic
+#endif
+  ptr[offset] += value;
+}
+} // namespace monai
+#endif
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#include <ATen/ATen.h>
+
+namespace monai {
+
+enum class BoundType : int64_t {
+  Replicate, // Replicate last inbound value = clip coordinates
+  DCT1, // Symmetric w.r.t. center of the last inbound voxel
+  DCT2, // Symmetric w.r.t. edge of the last inbound voxel (=Neuman)
+  DST1, // Asymmetric w.r.t. center of the last inbound voxel
+  DST2, // Asymmetric w.r.t. edge of the last inbound voxel (=Dirichlet)
+  DFT, // Circular / Wrap arounf the FOV
+  Sliding, // For deformation-fields only: mixture of DCT2 and DST2
+  Zero, // Zero outside of the FOV
+  NoCheck // /!\ Checks disabled: assume coordinates are inbound
+};
+
+using BoundVectorRef = c10::ArrayRef<BoundType>;
+
+enum class InterpolationType : int64_t {
+  Nearest,
+  Linear,
+  Quadratic,
+  Cubic,
+  FourthOrder,
+  FifthOrder,
+  SixthOrder,
+  SeventhOrder
+};
+using InterpolationVectorRef = c10::ArrayRef<InterpolationType>;
+
+static MONAI_INLINE MONAI_HOST std::ostream& operator<<(std::ostream& os, const BoundType& bound) {
+  switch (bound) {
+    case BoundType::Replicate:
+      return os << "Replicate";
+    case BoundType::DCT1:
+      return os << "DCT1";
+    case BoundType::DCT2:
+      return os << "DCT2";
+    case BoundType::DST1:
+      return os << "DST1";
+    case BoundType::DST2:
+      return os << "DST2";
+    case BoundType::DFT:
+      return os << "DFT";
+    case BoundType::Zero:
+      return os << "Zero";
+    case BoundType::Sliding:
+      return os << "Sliding";
+    case BoundType::NoCheck:
+      return os << "NoCheck";
+  }
+  return os << "Unknown bound";
+}
+
+static MONAI_INLINE MONAI_HOST std::ostream& operator<<(std::ostream& os, const InterpolationType& itp) {
+  switch (itp) {
+    case InterpolationType::Nearest:
+      return os << "Nearest";
+    case InterpolationType::Linear:
+      return os << "Linear";
+    case InterpolationType::Quadratic:
+      return os << "Quadratic";
+    case InterpolationType::Cubic:
+      return os << "Cubic";
+    case InterpolationType::FourthOrder:
+      return os << "FourthOrder";
+    case InterpolationType::FifthOrder:
+      return os << "FifthOrder";
+    case InterpolationType::SixthOrder:
+      return os << "SixthOrder";
+    case InterpolationType::SeventhOrder:
+      return os << "SeventhOrder";
+  }
+  return os << "Unknown interpolation order";
+}
+
+} // namespace monai

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -14,4 +14,4 @@ from .aliases import *
 from .decorators import *
 from .enums import *
 from .misc import *
-from .module import OptionalImportError, exact_version, export, min_version, optional_import
+from .module import *

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -35,8 +35,11 @@ class GridSampleMode(Enum):
     See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
     """
 
-    BILINEAR = "bilinear"
     NEAREST = "nearest"
+    BILINEAR = "bilinear"
+    QUADRATIC = "quadratic"
+    CUBIC = "cubic"
+    FOURTH = "fourth"
 
 
 class InterpolateMode(Enum):

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -17,6 +17,16 @@ from typing import Any, Callable, List, Tuple
 
 OPTIONAL_IMPORT_MSG_FMT = "{}"
 
+__all__ = [
+    "OptionalImportError",
+    "exact_version",
+    "export",
+    "min_version",
+    "optional_import",
+    "load_submodules",
+    "get_full_type_name",
+]
+
 
 def export(modname):
     """

--- a/tests/test_split_dataset.py
+++ b/tests/test_split_dataset.py
@@ -1,0 +1,36 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from parameterized import parameterized
+
+from monai.apps import split_dataset
+
+TEST_CASE_1 = [{"nsplits": 5, "length": 10}, [[0, 2], [2, 4], [4, 6], [6, 8], [8, 10]]]
+
+TEST_CASE_2 = [{"nsplits": 5, "length": 13}, [[0, 3], [3, 6], [6, 9], [9, 11], [11, 13]]]
+
+TEST_CASE_3 = [{"nsplits": 5, "length": 11}, [[0, 3], [3, 5], [5, 7], [7, 9], [9, 11]]]
+
+TEST_CASE_4 = [{"nsplits": 1, "length": 10}, [[0, 10]]]
+
+
+class TestSplitDataset(unittest.TestCase):
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
+    def test_shape(self, input_param, expected_indices):
+        indices = split_dataset(**input_param)
+        for data, expected in zip(indices, expected_indices):
+            self.assertListEqual(data, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Check the README.

# Randomization issue with openers

`substratools.Opener` requests that user implement both `get_X` and `get_y`. It gets really tricky when using a randomized batch iterator like DataLoader because we cannot instantiate 2 DataLoader (one in each method) on the same data samples because each loader would be randomized differently and `X_i` would not match `y_i`.

Also we cannot use a randomized loader for testtuple, otherwise the order of items in y_pred (generated from one instance of the loader) would not match the one in y_true (generated from another instance of the loader).


A good solution would be to be able to set the order of data samples in the testtuple but this is currently not supported by substra. This way the randomization could be done outside of the opener.

Note: the randomization is especially important when trying to run multiple epochs (with randomization happing in-between epochs). In substra however each epoch should be a separate traintuple. So it would be perfectly possible to randomize differently the order of data samples at each traintuple.

In the meantime, here are a few solutions:

1. Have a separate opener for training and one for testing. This is necessary if we want to keep the randomization.

2. Only load the data once during training, either by:
  a. having get_y return None and get_X return the loader (implemented here)
  b. having get_y and get_X return iterators that iterate over separate parts of the loader (can be tricky)

# About run-local

Attempting to run the example using `substra run-local` raise a memory error. By patching the code of the runner in the substra repo as follows I was able to run it without trouble. The patch is inspired by code found in substra-backend.

```diff
diff --git a/substra/runner.py b/substra/runner.py
index d995950..42b9d9b 100644
--- a/substra/runner.py
+++ b/substra/runner.py
@@ -21,6 +21,7 @@ import tempfile
 import time
 import hashlib
 import zipfile
+from subprocess import check_output

 import docker

@@ -84,6 +85,35 @@ def _docker_build(docker_client, dockerfile_path, name, rm=False):
 def _docker_run(docker_client, name, command, volumes, remove=True):
     print(f'Running docker {name}', end=' ', flush=True)
     start = time.time()
+
+    # memory_limit_mb = f'{resources_manager.memory_limit_mb()}M'
+    # cpu_set, gpu_set = resources_manager.get_cpu_gpu_sets()    # blocking call
+
+    try:
+        memory_limit_mb = int(os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') / (1024. ** 2))
+    except ValueError:
+        memory_limit_mb = int(check_output(['sysctl', '-n', 'hw.memsize']).strip())
+
+    task_args = {
+        'image': name,
+        # 'name': container_name,
+        # 'cpuset_cpus': cpu_set,
+        'mem_limit': f"{memory_limit_mb}M",
+        'command': command,
+        'volumes': volumes,
+        'shm_size': '8G',
+        # 'labels': [DOCKER_LABEL],
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': False,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+        # 'environment': environment
+    }
     try:
         # Setting userns_mode to "host" effectively turns off user namespaces
         # (see https://github.com/moby/moby/issues/25492#issuecomment-239173095).
@@ -91,9 +121,10 @@ def _docker_run(docker_client, name, command, volumes, remove=True):
         # filesystem from the container.
         # It is safe to do because we also use the user=USER option: the `UID`
         # in the container is set to the `UID` of the current process.
-        docker_client.containers.run(name, command=command,
-                                     volumes=volumes, remove=remove, user=USER,
-                                     userns_mode="host")
+        # docker_client.containers.run(name, command=command,
+        #                              volumes=volumes, remove=remove, user=USER,
+        #                              userns_mode="host")
+        docker_client.containers.run(**task_args)
     except docker.errors.ContainerError as e:
         # try to pretty print traceback
         try:
``` 